### PR TITLE
ci: add DADL validation workflow and schema

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,22 @@
+name: Validate DADL Files
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - name: Validate all DADL files
+        run: npm run validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,648 @@
+{
+  "name": "dadl-registry",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dadl-registry",
+      "version": "0.1.0",
+      "devDependencies": {
+        "ajv": "^8.17.1",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0",
+        "yaml": "^2.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dadl-registry",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "tsx scripts/validate-all.ts"
+  },
+  "devDependencies": {
+    "ajv": "^8.17.1",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "yaml": "^2.6.0"
+  }
+}

--- a/schema/dadl-v1.schema.json
+++ b/schema/dadl-v1.schema.json
@@ -1,0 +1,563 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dadl.ai/schema/dadl-v1.schema.json",
+  "title": "DADL — Dunkel API Description Language v0.1",
+  "description": "Schema for .dadl files — declarative YAML descriptions of REST APIs for ToolMesh",
+  "type": "object",
+  "required": ["spec", "backend"],
+  "properties": {
+    "spec": {
+      "type": "string",
+      "description": "URL of the DADL specification this file conforms to"
+    },
+    "credits": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Free-form list of contributors, maintainers, and sponsors"
+    },
+    "source_name": {
+      "type": "string",
+      "description": "Name of the source API being described"
+    },
+    "source_url": {
+      "type": "string",
+      "description": "URL to the original API documentation"
+    },
+    "date": {
+      "type": "string",
+      "description": "Creation or last-modified date (YYYY-MM-DD)"
+    },
+    "backend": {
+      "$ref": "#/$defs/Backend"
+    },
+    "includes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Include"
+      },
+      "description": "Reusable fragments to merge in"
+    }
+  },
+  "patternProperties": {
+    "^_": {
+      "description": "Underscore-prefixed keys are ignored by ToolMesh (used for YAML anchors)"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "Backend": {
+      "type": "object",
+      "required": ["name", "type", "description", "auth", "tools"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$",
+          "description": "Unique backend identifier (slug format: lowercase, hyphens)"
+        },
+        "type": {
+          "type": "string",
+          "const": "rest",
+          "description": "Backend type — always 'rest' for DADL"
+        },
+        "version": {
+          "type": "string",
+          "description": "Semantic version of this DADL file (e.g. '1.0', '1.2.1'). Used for upgrade detection."
+        },
+        "base_url": {
+          "type": "string",
+          "description": "Base URL for all API requests"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description"
+        },
+        "openapi_source": {
+          "type": "string",
+          "description": "Path or URL to OpenAPI 3.x spec"
+        },
+        "arazzo_source": {
+          "type": "string",
+          "description": "Path or URL to Arazzo workflow file"
+        },
+        "auth": {
+          "$ref": "#/$defs/Auth"
+        },
+        "defaults": {
+          "$ref": "#/$defs/Defaults"
+        },
+        "types": {
+          "type": "object",
+          "description": "Type definitions (JSON Schema subset)",
+          "additionalProperties": true
+        },
+        "tools": {
+          "type": "object",
+          "description": "Map of tool definitions",
+          "additionalProperties": {
+            "$ref": "#/$defs/Tool"
+          },
+          "minProperties": 1
+        },
+        "composites": {
+          "type": "object",
+          "description": "Composite tool definitions (server-side TypeScript)",
+          "additionalProperties": {
+            "$ref": "#/$defs/Composite"
+          }
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Example"
+          },
+          "description": "Code examples for multi-step workflows"
+        },
+        "coverage": {
+          "$ref": "#/$defs/Coverage"
+        },
+        "hints": {
+          "type": "object",
+          "description": "Per-tool domain knowledge for LLM consumers",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "setup": {
+          "$ref": "#/$defs/Setup"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Auth": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["bearer", "basic", "oauth2", "session", "api_key", "apikey"],
+          "description": "Authentication type"
+        },
+        "credential": {
+          "type": "string",
+          "description": "Credential reference for bearer/api_key"
+        },
+        "inject_into": {
+          "type": "string",
+          "enum": ["header", "query"],
+          "description": "Where to inject the credential"
+        },
+        "header_name": {
+          "type": "string",
+          "description": "HTTP header name for injection"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Value prefix (e.g. 'Bearer ')"
+        },
+        "query_param": {
+          "type": "string",
+          "description": "Query parameter name for api_key injection"
+        },
+        "username_credential": {
+          "type": "string",
+          "description": "Username credential reference (basic auth)"
+        },
+        "password_credential": {
+          "type": "string",
+          "description": "Password credential reference (basic auth)"
+        },
+        "flow": {
+          "type": "string",
+          "description": "OAuth2 flow type"
+        },
+        "token_url": {
+          "type": "string",
+          "description": "OAuth2 token endpoint"
+        },
+        "client_id_credential": {
+          "type": "string",
+          "description": "OAuth2 client ID credential"
+        },
+        "client_secret_credential": {
+          "type": "string",
+          "description": "OAuth2 client secret credential"
+        },
+        "scopes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "OAuth2 scopes"
+        },
+        "token_cache_key": {
+          "type": "string",
+          "description": "OAuth2 token cache key"
+        },
+        "refresh_before_expiry": {
+          "type": "string",
+          "description": "OAuth2 token refresh window"
+        },
+        "login": {
+          "type": "object",
+          "description": "Session-based login config"
+        },
+        "inject": {
+          "type": "array",
+          "description": "Session-based header injection"
+        },
+        "refresh": {
+          "type": "object",
+          "description": "Session-based refresh config"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Defaults": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Default HTTP headers"
+        },
+        "pagination": {
+          "$ref": "#/$defs/Pagination"
+        },
+        "errors": {
+          "$ref": "#/$defs/Errors"
+        },
+        "response": {
+          "$ref": "#/$defs/Response"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Pagination": {
+      "type": "object",
+      "properties": {
+        "strategy": {
+          "type": "string",
+          "enum": ["cursor", "offset", "page", "link_header"],
+          "description": "Pagination strategy"
+        },
+        "request": {
+          "type": "object",
+          "properties": {
+            "cursor_param": { "type": "string" },
+            "page_param": { "type": "string" },
+            "offset_param": { "type": "string" },
+            "limit_param": { "type": "string" },
+            "limit_default": { "type": "integer" },
+            "limit_max": { "type": "integer" }
+          },
+          "additionalProperties": false
+        },
+        "response": {
+          "type": "object",
+          "properties": {
+            "next_cursor": { "type": "string" },
+            "has_more": { "type": "string" },
+            "total_pages_header": { "type": "string" },
+            "next_link_header": { "type": "string" },
+            "total_header": { "type": "string" },
+            "current_page_header": { "type": "string" },
+            "next_page_header": { "type": "string" },
+            "per_page_header": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "behavior": {
+          "type": "string",
+          "enum": ["auto", "expose", "manual"],
+          "description": "Pagination behavior"
+        },
+        "max_pages": {
+          "type": "integer",
+          "description": "Safety limit for max pages"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Errors": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": ["json", "text", "xml"]
+        },
+        "message_path": { "type": "string" },
+        "code_path": { "type": "string" },
+        "retry_on": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "terminal": {
+          "type": "array",
+          "items": { "type": "integer" }
+        },
+        "retry_strategy": {
+          "type": "object",
+          "properties": {
+            "max_retries": { "type": "integer" },
+            "backoff": { "type": "string" },
+            "initial_delay": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "rate_limit": {
+          "type": "object",
+          "properties": {
+            "header": { "type": "string" },
+            "retry_after_header": { "type": "string" },
+            "requests_per_second": { "type": "number" }
+          },
+          "additionalProperties": false
+        },
+        "rate_limit_headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Rate limit response header names"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Response": {
+      "type": "object",
+      "properties": {
+        "result_path": { "type": "string" },
+        "metadata_path": { "type": "string" },
+        "transform": { "type": "string" },
+        "max_items": { "type": "integer" },
+        "allow_jq_override": { "type": "boolean" },
+        "type": { "type": "string" },
+        "ttl": { "type": "string" },
+        "binary": { "type": "boolean" },
+        "content_type": { "type": "string" },
+        "streaming": { "type": "boolean" },
+        "stream_handling": { "type": "string" },
+        "max_duration": { "type": "string" },
+        "max_items_stream": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
+    "Tool": {
+      "type": "object",
+      "required": ["method", "path", "description"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+          "description": "HTTP method"
+        },
+        "path": {
+          "type": "string",
+          "description": "URL path with optional {param} placeholders"
+        },
+        "access": {
+          "type": "string",
+          "description": "Access classification for authorization and policy mapping. Well-known values: read, write, admin, dangerous. Custom values allowed."
+        },
+        "description": {
+          "type": "string",
+          "description": "Tool description (used as JSDoc comment)"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Param"
+          }
+        },
+        "content_type": {
+          "type": "string",
+          "description": "Request content type"
+        },
+        "max_body_size": {
+          "type": "string",
+          "description": "Max upload size"
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Tools that should be called first"
+        },
+        "response": {
+          "$ref": "#/$defs/Response"
+        },
+        "pagination": {
+          "description": "'none' to disable or object to override",
+          "oneOf": [
+            { "type": "string", "const": "none" },
+            { "$ref": "#/$defs/Pagination" }
+          ]
+        },
+        "errors": {
+          "$ref": "#/$defs/Errors"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Param": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["string", "integer", "number", "boolean", "array", "object", "file_url"],
+          "description": "Parameter type"
+        },
+        "in": {
+          "type": "string",
+          "enum": ["path", "query", "body", "header"],
+          "description": "Parameter location"
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether the parameter is required"
+        },
+        "default": {
+          "description": "Default value"
+        },
+        "description": {
+          "type": "string",
+          "description": "Parameter description"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Composite": {
+      "type": "object",
+      "required": ["description", "code"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Composite tool description"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string" },
+              "default": {},
+              "description": { "type": "string" },
+              "required": { "type": "boolean" }
+            }
+          }
+        },
+        "code": {
+          "type": "string",
+          "description": "TypeScript/JavaScript function body"
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Max execution time"
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Example": {
+      "type": "object",
+      "required": ["name", "code"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Coverage": {
+      "type": "object",
+      "properties": {
+        "endpoints": {
+          "type": "integer",
+          "description": "Number of tools defined"
+        },
+        "total_endpoints": {
+          "type": "integer",
+          "description": "Total endpoints in the target API"
+        },
+        "percentage": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Coverage percentage"
+        },
+        "focus": {
+          "type": "string",
+          "description": "Covered API areas"
+        },
+        "missing": {
+          "type": "string",
+          "description": "Uncovered API areas"
+        },
+        "last_reviewed": {
+          "type": "string",
+          "description": "Date when coverage was last verified"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Setup": {
+      "type": "object",
+      "properties": {
+        "credential_steps": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Step-by-step credential instructions"
+        },
+        "env_var": {
+          "type": "string",
+          "description": "Environment variable name"
+        },
+        "backends_yaml": {
+          "type": "string",
+          "description": "Example backends.yaml entry"
+        },
+        "required_scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "optional_scopes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "docs_url": {
+          "type": "string",
+          "description": "Authentication documentation URL"
+        },
+        "notes": {
+          "type": "string",
+          "description": "Additional setup notes"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Include": {
+      "type": "object",
+      "required": ["path", "merge_into"],
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "merge_into": {
+          "type": "string"
+        },
+        "overrides": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/validate-all.ts
+++ b/scripts/validate-all.ts
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync } from "fs";
+import { join, basename } from "path";
+import Ajv from "ajv";
+import { parse as parseYaml } from "yaml";
+
+const ROOT_DIR = join(import.meta.dirname, "..");
+const SCHEMA_PATH = join(ROOT_DIR, "schema", "dadl-v1.schema.json");
+const MAX_FILE_SIZE = 500 * 1024; // 500 KB
+
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf-8"));
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+const files = readdirSync(ROOT_DIR).filter((f) => f.endsWith(".dadl"));
+
+if (files.length === 0) {
+  console.error("No .dadl files found in repository root.");
+  process.exit(1);
+}
+
+let hasErrors = false;
+
+for (const file of files) {
+  const filePath = join(ROOT_DIR, file);
+  const errors: string[] = [];
+
+  // Size check
+  const raw = readFileSync(filePath);
+  if (raw.length > MAX_FILE_SIZE) {
+    errors.push(`File exceeds 500 KB limit (${(raw.length / 1024).toFixed(0)} KB)`);
+  }
+
+  // Parse YAML
+  let doc: any;
+  try {
+    doc = parseYaml(raw.toString("utf-8"), { maxAliasCount: 100 });
+  } catch (e: any) {
+    errors.push(`YAML parse error: ${e.message}`);
+    console.error(`\n❌ ${file}`);
+    errors.forEach((e) => console.error(`   ${e}`));
+    hasErrors = true;
+    continue;
+  }
+
+  // Schema validation
+  const valid = validate(doc);
+  if (!valid && validate.errors) {
+    for (const err of validate.errors) {
+      errors.push(`Schema: ${err.instancePath || "/"} ${err.message}`);
+    }
+  }
+
+  // Filename must match backend.name
+  const expectedName = basename(file, ".dadl");
+  const backendName = doc?.backend?.name;
+  if (backendName && backendName !== expectedName) {
+    errors.push(
+      `Filename "${expectedName}" does not match backend.name "${backendName}"`
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error(`\n❌ ${file}`);
+    errors.forEach((e) => console.error(`   ${e}`));
+    hasErrors = true;
+  } else {
+    const toolCount = doc.backend?.tools
+      ? Object.keys(doc.backend.tools).length
+      : 0;
+    const compositeCount = doc.backend?.composites
+      ? Object.keys(doc.backend.composites).length
+      : 0;
+    const suffix = compositeCount > 0 ? ` + ${compositeCount} composites` : "";
+    console.log(`✅ ${file} — ${toolCount} tools${suffix}`);
+  }
+}
+
+if (hasErrors) {
+  console.error("\nValidation failed.");
+  process.exit(1);
+} else {
+  console.log(`\n✅ All ${files.length} DADL files valid.`);
+}


### PR DESCRIPTION
## Summary

- Adds `validate-pr.yml` workflow: runs on PRs and pushes to main
- Includes JSON schema (`dadl-v1.schema.json`), validation script, and dependencies
- Contributors can validate locally: `npm install && npm run validate`

This ensures new DADL submissions are validated before merge.