### PR TITLE
feat: make credits, source_name, source_url, date required in schema

### DIFF
--- a/schema/dadl-v1.schema.json
+++ b/schema/dadl-v1.schema.json
@@ -4,7 +4,7 @@
   "title": "DADL — Dunkel API Description Language v0.1",
   "description": "Schema for .dadl files — declarative YAML descriptions of REST APIs for ToolMesh",
   "type": "object",
-  "required": ["spec", "backend"],
+  "required": ["spec", "credits", "source_name", "source_url", "date", "backend"],
   "properties": {
     "spec": {
       "type": "string",
@@ -13,18 +13,22 @@
     "credits": {
       "type": "array",
       "items": { "type": "string" },
+      "minItems": 1,
       "description": "Free-form list of contributors, maintainers, and sponsors"
     },
     "source_name": {
       "type": "string",
+      "minLength": 1,
       "description": "Name of the source API being described"
     },
     "source_url": {
       "type": "string",
+      "pattern": "^https?://",
       "description": "URL to the original API documentation"
     },
     "date": {
       "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
       "description": "Creation or last-modified date (YYYY-MM-DD)"
     },
     "backend": {
@@ -356,7 +360,7 @@
         },
         "access": {
           "type": "string",
-          "description": "Access classification for authorization and policy mapping. Well-known values: read, write, admin, dangerous. Custom values allowed."
+          "description": "Access classification for authorization and policy mapping. Well-fnown values: read, write, admin, dangerous. Custom values allowed."
         },
         "description": {
           "type": "string",


### PR DESCRIPTION
Makes `credits`, `source_name`, `source_url`, and `date` required header fields in the DADL v1 schema, with format validation.

**Changes:**
- `required` array extended to include `credits`, `source_name`, `source_url`, `date`
- `source_url` validated against `^https?://` pattern
- `date` validated against `^\d{4}-\d{2}-\d{2}$` (YYYY-MM-DD)
- `credits` requires `minItems: 1`
- `source_name` requires `minLength: 1`

Existing DADLs (github, gitlab, vikunja) need these fields added before merging.