### PR TITLE
fix: include task IDs in list_project_tasks response

### DIFF
--- a/vikunja.dadl
+++ b/vikunja.dadl
@@ -135,7 +135,7 @@ backend:
         s: { type: string, in: query }
       response:
         transform: |
-          [.[] | {title: .title, tasks: [.tasks[]? | {id: .id, identifier: .identifier, title: .title, priority: .priority, done: .done, due_date: .due_date, labels: [.labels[]?.title]}]}]
+          [.[] | if .tasks then {bucket_id: .id, title: .title, tasks: [.tasks[]? | {id: .id, identifier: .identifier, title: .title, priority: .priority, done: .done, due_date: .due_date, labels: [.labels[]?.title]}]} else {id: .id, identifier: .identifier, title: .title, priority: .priority, done: .done, due_date: .due_date, labels: [.labels[]?.title]} end]
         allow_jq_override: true
 
     get_task:


### PR DESCRIPTION
## Summary

- Fix jq transform to detect list vs. kanban view response format
- List views now return flat tasks with `id`, `identifier`, `title`, etc.
- Kanban views return buckets with `bucket_id` + nested tasks with `id`

Fixes #20