### PR TITLE
fix: remove dead pagination response config in algolia-hn-search

### DIFF
--- a/algolia-hn-search.dadl
+++ b/algolia-hn-search.dadl
@@ -81,9 +81,9 @@ backend:
         page_param: page
         limit_param: hitsPerPage
         limit_default: 20
-      response:
-        total_pages_header: x-total-pages
-        current_page_header: x-current-page
+      # Algolia returns nbHits/nbPages/page in the JSON body, not in headers,
+      # and the DADL spec has no body-path pagination fields. behavior: expose
+      # surfaces page/hitsPerPage as tool params; LLMs read nbPages off result.
       behavior: expose
       max_pages: 50
     errors:


### PR DESCRIPTION
## Summary

`algolia-hn-search.dadl` had a `pagination.response` block that did nothing:

```yaml
response:
  total_pages_header: x-total-pages
  current_page_header: x-current-page   # ← not in the DADL schema, dropped by yaml.v3
```

Algolia returns pagination metadata (`nbHits`, `nbPages`, `page`, `hitsPerPage`) in the JSON response body — the `x-total-pages` header is not actually returned. And `current_page_header` isn't part of the DADL pagination schema at all, so yaml.v3 silently dropped it on parse.

The DADL pagination schema currently has no body-path fields, so body-based pagination metadata cannot be expressed declaratively. With `behavior: expose`, `page` / `hitsPerPage` are surfaced as tool params and the LLM reads `nbPages` off the response — which is what already happens in practice. The dead `response.*` block is dropped, a short comment documents the limitation.

`npm run validate` passes; all 18 DADLs still valid.