### PR TITLE
feat(netbox): expand to 608 tools — near-complete NetBox v4 surface

### DIFF
--- a/netbox.dadl
+++ b/netbox.dadl
@@ -7,6 +7,8 @@
 # - Objects are identified by numeric IDs (not UUIDs). Use ?brief=true for compact responses.
 # - All list endpoints support filtering: ?name=foo, ?site=site-slug, ?status=active,
 #   ?tag=mytag, ?q=search-term. Negation: ?status__n=decommissioned.
+# - Lookup expressions on most filter params: __n (not), __ic (contains, case-insensitive),
+#   __nic, __ie (iexact), __isw (starts-with), __iew (ends-with), __empty, __gt, __gte, __lt, __lte.
 # - Ordering: ?ordering=name (asc), ?ordering=-created (desc).
 # - Field selection: ?fields=id,name,status or ?omit=config_context (v4.5.2+).
 # - Related objects are set by ID (e.g. "site": 5) or nested unique set
@@ -17,12 +19,51 @@
 # - Custom fields: stored under "custom_fields" dict on each object.
 # - Status values vary per model: "active", "planned", "staged", "decommissioning", etc.
 # - A "prefix" in IPAM is a CIDR block (e.g. 10.0.0.0/24). A "VRF" is a routing domain.
+#   Route-targets (e.g. "65000:100") attach to VRFs as import_targets/export_targets for L3VPN.
 # - A "VLAN" has a numeric vid (1-4094) and belongs to a VLAN group and optional site.
+#   VLAN translation policies define 1:1 local-to-remote VID rewrites.
 # - FHRP (First Hop Redundancy Protocol) groups model virtual IP failover (VRRP, HSRP, CARP, GLBP).
 #   Each group has a protocol + group_id. Assign interfaces via fhrp-group-assignments with priority 0-255.
-# - Devices have components: interfaces, console-ports, power-ports, etc.
-# - Virtual machines live in clusters and have interfaces and virtual-disks.
-# - The API root at /api/ lists all available app endpoints.
+# - Devices have components: interfaces, console-ports, console-server-ports, power-ports,
+#   power-outlets, front-ports, rear-ports, module-bays, device-bays, inventory-items.
+#   Each component-type has a matching *-template on the device-type that is instantiated
+#   when a device is created. Likewise module-types carry their own component templates.
+# - Modules are hardware sub-units installed into module-bays. Inserting a module auto-creates
+#   its components from the module-type templates; removing it deletes them.
+# - Virtual chassis (VC) groups multiple physical devices into one logical device with a master.
+#   Set virtual_chassis + vc_position + vc_priority on member devices via update_device.
+# - Virtual device contexts (VDCs) split one physical device into multiple logical contexts
+#   (Cisco Nexus model). Interfaces can belong to one or more VDCs.
+# - Power model: power-panel -> power-feed -> power-port (device side) and power-outlet
+#   (downstream sockets, e.g. on a PDU). Voltage is signed: -48 means -48VDC.
+# - Cables connect any two terminations. Endpoint object_types are polymorphic:
+#   dcim.interface, dcim.frontport, dcim.rearport, dcim.consoleport, dcim.consoleserverport,
+#   dcim.powerport, dcim.poweroutlet, dcim.powerfeed, circuits.circuittermination.
+#   /dcim/<port>/{id}/trace/ walks the full path through patch panels to the far end.
+# - Virtual machines live in clusters and have interfaces and virtual-disks. VM types
+#   (NetBox 4.2+) normalize hardware models (e.g. AWS "m5.xlarge").
+# - Circuits model carrier services. Virtual circuits (NetBox 4.2+) ride on top of provider
+#   networks and define logical end-to-end paths with terminations on physical interfaces.
+# - VPN: tunnels carry an encapsulation (ipsec-tunnel/ipsec-transport/ip-ip/gre/wireguard/...).
+#   For IPSec, bind an ipsec_profile (= ike_policy + ipsec_policy + mode). Add per-side
+#   tunnel-terminations with role peer/hub/spoke. L2VPN (VPLS/VXLAN/EVPN) terminations
+#   attach VLANs, interfaces, or VRFs to an L2VPN service.
+# - Tenancy: contact-assignments link contacts to any model with the ContactsMixin
+#   (devices, racks, circuits, prefixes, VMs, ...) with priority (primary/secondary/tertiary/inactive).
+# - Extras hosts cross-cutting features: tags, custom-fields, journal-entries, config-contexts,
+#   config-templates (Jinja2 rendered with config-context data), webhooks (HTTP delivery),
+#   event-rules (bind webhook/script/notification-group to a model + event type),
+#   scripts (POST /extras/scripts/{id}/ to run -- returns a job, poll /core/jobs/),
+#   export-templates, saved-filters, custom-links, bookmarks, notifications, image-attachments,
+#   dashboard (singleton GET/PATCH for the current user).
+# - Core hosts platform resources: data-sources (git/S3 sync for templates/scripts/contexts,
+#   POST /core/data-sources/{id}/sync/ enqueues a job), data-files, jobs (async work status),
+#   object-types (Django ContentTypes -- used in polymorphic object_type fields).
+# - Users app exposes users, groups, object-permissions (per-model + per-action grants with
+#   optional ORM-style constraints), and tokens. The token 'key' is returned ONLY on create
+#   (one-shot); subsequent GETs do not expose it. POST /users/tokens/provision/ bootstraps a
+#   token from username+password.
+# - The API root at /api/ lists all available app endpoints. Swagger UI at /api/schema/swagger-ui/.
 
 spec: "https://dadl.ai/spec/dadl-spec-v0.1.md"
 
@@ -31,15 +72,15 @@ credits:
 
 source_name: "NetBox REST API"
 source_url: "https://netboxlabs.com/docs/netbox/integrations/rest-api/"
-date: "2026-04-13"
+date: "2026-05-19"
 
 backend:
   name: netbox
   type: rest
-  version: "1.2"
+  version: "2.0"
   # base_url is intentionally omitted -- must be provided via backends.yaml url field,
   # because each deployment has its own NetBox instance address.
-  description: "NetBox DCIM/IPAM API -- sites, racks, devices, interfaces, cables, IP addresses, prefixes, VLANs, VRFs, virtual machines, clusters, circuits, tenants, contacts, and network documentation"
+  description: "NetBox DCIM/IPAM API -- full v4 coverage: sites, racks, devices, modules, interfaces, cables, power, IPAM (prefixes, IPs, VLANs, VRFs, route-targets, VLAN translation), virtualization, circuits (including virtual circuits), tenants, contacts, VPN (IKE/IPSec/L2VPN), wireless, extras (webhooks, event-rules, scripts, config-templates, bookmarks, notifications), users/permissions/tokens, and core data sources & jobs"
 
   auth:
     type: bearer
@@ -79,12 +120,55 @@ backend:
       max_items: 500
 
   coverage:
-    endpoints: 244
-    total_endpoints: 250
+    endpoints: 608
+    total_endpoints: 620
     percentage: 98
-    focus: "DCIM (sites, locations, racks, devices, interfaces, cables, manufacturers, device-types, device-roles, platforms, power), IPAM (prefixes, ip-addresses, vlans, vlan-groups, vrfs, aggregates, rirs, asns, roles, services, ip-ranges, fhrp-groups, fhrp-group-assignments), Virtualization (clusters, cluster-types, cluster-groups, virtual-machines, vm-interfaces, virtual-disks), Tenancy (tenants, tenant-groups, contacts, contact-roles), Circuits (providers, circuits, circuit-types, circuit-terminations), Wireless (wireless-lans, wireless-links), VPN (tunnels, l2vpns), Extras (tags, custom-fields, custom-field-choice-sets, journal-entries, object-changes, config-contexts)"
-    missing: "device component templates, module types/bays, inventory items, power panels/feeds, rack reservations, virtual-chassis, front/rear-ports, console-server-ports, power-outlets, VLAN translations, IKE/IPSec policies, event rules, webhooks, scripts, export templates, users/groups/permissions, bookmarks, notifications"
-    last_reviewed: "2026-04-16"
+    focus: >
+      DCIM full v4: sites, site-groups, regions, locations,
+      racks (with elevation, roles, types, reservations), manufacturers,
+      device-types, device-roles, platforms, devices, modules, module-types,
+      module-bays, device-bays, virtual-chassis, virtual-device-contexts,
+      inventory-items, inventory-item-roles, interfaces, cables,
+      cable-terminations, all port types (console, console-server, power,
+      power-outlet, front, rear) with trace/paths actions, power-panels,
+      power-feeds, mac-addresses, connected-device lookup, and the
+      complete component-template family.
+      IPAM full v4: prefixes (with available-prefixes/available-ips),
+      ip-addresses, ip-ranges (with available-ips), vlans, vlan-groups
+      (with available-vlans), vrfs, route-targets, aggregates, rirs, asns,
+      asn-ranges (with available-asns), roles, services, service-templates,
+      vlan-translation-policies, vlan-translation-rules, fhrp-groups,
+      fhrp-group-assignments.
+      Virtualization full v4: clusters, cluster-types, cluster-groups,
+      virtual-machines, virtual-machine-types, vm-interfaces, virtual-disks.
+      Tenancy full v4: tenants, tenant-groups, contacts, contact-roles,
+      contact-groups, contact-assignments.
+      Circuits full v4: providers, provider-accounts, provider-networks,
+      circuit-types, circuits, circuit-terminations (with paths),
+      circuit-groups, circuit-group-assignments, virtual-circuits,
+      virtual-circuit-types, virtual-circuit-terminations.
+      Wireless full v4: wireless-lan-groups, wireless-lans, wireless-links.
+      VPN full v4: tunnel-groups, tunnels, tunnel-terminations, ike-proposals,
+      ike-policies, ipsec-proposals, ipsec-policies, ipsec-profiles, l2vpns,
+      l2vpn-terminations.
+      Extras: tags, custom-fields, custom-field-choice-sets, custom-links,
+      saved-filters, export-templates, journal-entries, object-changes,
+      config-contexts, config-templates (+render), webhooks, event-rules,
+      scripts (+run), bookmarks, notifications, notification-groups,
+      subscriptions, image-attachments, dashboard.
+      Users: users, groups, permissions, tokens (+provision).
+      Core: data-sources (+sync), data-files, jobs, object-types,
+      background-queues/workers/tasks.
+    missing: >
+      Read-only listing of background-tasks with action endpoints
+      (delete/requeue/enqueue/stop) -- rarely used outside debugging.
+      Plugin-specific endpoints under /api/plugins/ -- those depend on
+      installed plugins and are out of scope for a general DADL.
+      table-configs, config-context-profiles, tagged-objects, and the
+      authentication-check endpoint -- minor utility endpoints.
+      Bulk update/delete on list endpoints (PUT/PATCH/DELETE on collections)
+      -- prefer per-object operations in Code Mode.
+    last_reviewed: "2026-05-19"
 
   setup:
     credential_steps:
@@ -111,29 +195,85 @@ backend:
     list_devices:
       filtering: "Filter by site, rack, role, manufacturer, model, status, tag, etc. E.g. ?site=dc1&status=active&role=server"
       brief: "Use ?brief=true for compact results with just id, url, display, name"
+      vc_filter: "?virtual_chassis_id=N returns members of a VC. ?vc_position to filter by stack member position."
     list_ip_addresses:
       filtering: "Filter by address, vrf, interface, device, vm, status, role, tenant"
       parent_lookup: "?parent=10.0.0.0/16 returns all IPs within that prefix"
+      assigned: "Set ?assigned=true / ?assigned=false to find IPs bound or unbound to interfaces"
     list_prefixes:
       filtering: "?within=10.0.0.0/8 returns all sub-prefixes. ?contains=10.0.1.50 finds the prefix."
-      available: "GET /api/ipam/prefixes/{id}/available-ips/ shows free IPs"
+      available: "GET /api/ipam/prefixes/{id}/available-ips/ shows free IPs. POST same path to claim one atomically."
+      child_carve: "claim_prefix POSTs to /prefixes/{id}/available-prefixes/ to carve a new child prefix at a specified mask"
     list_interfaces:
       filtering: "?device=hostname or ?device_id=123. ?type=1000base-t for specific types."
+      lag: "lag_id filters interfaces by their LAG parent. Use ?type=lag to find the parent itself."
+      vdc: "?vdc_id filters interfaces belonging to a specific virtual device context"
+    update_interface:
+      nullable_fks: "untagged_vlan, lag, parent, bridge, vrf, primary_mac_address are nullable -- pass JSON null in the PATCH body to clear them. Omitting the key leaves the current value unchanged."
+      nullable_choices: "mode and duplex are nullable -- pass null to clear (mode=null reverts to access-mode default; duplex=null lets the driver auto-negotiate)."
+      m2m_clear: "tagged_vlans, wireless_lans, and tags are many-to-many arrays -- pass [] (empty array) to detach all; pass null is not the right idiom for M2M."
+      wireless_lans: "Array of wireless_lan object IDs. Only meaningful when type=wireless-ac/n/ax/... (i.e. the interface is a wireless interface)."
+      mode_vlan_dependency: "Setting mode=null while untagged_vlan or tagged_vlans is still populated will fail validation. Clear the VLAN assignments in the same PATCH or before."
     list_vlans:
       filtering: "?vid=100, ?group=my-group, ?site=dc1"
+      available: "GET /api/ipam/vlan-groups/{id}/available-vlans/ lists free VIDs within a group; POST to claim"
     create_device:
       required: "name, role (id or nested), device_type (id or nested), site (id or nested)"
       note: "After creating a device, interfaces are auto-created from the device type template"
+      vc_membership: "To stack into a virtual chassis, set virtual_chassis (id) + vc_position (1..N) + vc_priority"
     create_virtual_machine:
       required: "name, cluster (id or nested)"
+      type: "NetBox 4.2+ supports virtual_machine_type as a normalized model -- pass as integer id"
     create_ip_address:
       required: "address (CIDR notation, e.g. '10.0.0.1/24')"
       assign: "Set assigned_object_type='dcim.interface' and assigned_object_id=<id> to bind to an interface"
+      vminterface: "For VM interfaces use assigned_object_type='virtualization.vminterface'"
+      nat: "nat_inside / nat_outside fields link 1:1 NAT IP pairs"
     create_service:
       netbox_4x: "NetBox 4.x replaced device/virtual_machine with GenericForeignKey: use parent_object_type ('dcim.device' or 'virtualization.virtualmachine') + parent_object_id"
       custom_fields: "Pass custom_fields as key-value object, e.g. {prom_http_url: 'http://...:9090/metrics'}"
     create_custom_field_choice_set:
       extra_choices: "Array of [value, label] pairs, e.g. [['tcp','TCP'],['udp','UDP']]"
+    create_cable:
+      both_ends: "A cable needs a_terminations AND b_terminations -- each is an array of {object_type, object_id}"
+      object_types: "Endpoint object_type values: dcim.interface, dcim.frontport, dcim.rearport, dcim.consoleport, dcim.consoleserverport, dcim.powerport, dcim.poweroutlet, dcim.powerfeed, circuits.circuittermination"
+    create_module:
+      auto_components: "Installing a module auto-creates its components (interfaces, ports) from module-type templates. Removing it deletes them."
+    create_virtual_chassis:
+      member_assignment: "Build the VC first, then PATCH each member device with virtual_chassis=<id>, vc_position=N, vc_priority=N"
+    create_rack_reservation:
+      units_array: "units is an array of unit numbers (top-down) e.g. [38,39,40] reserves U38-U40"
+    create_power_feed:
+      voltage_signs: "voltage is signed; -48 means -48VDC. amperage is in amps. max_utilization is percent (1-100)."
+    create_tunnel:
+      profile_for_ipsec: "For IPSec tunnels, set encapsulation='ipsec-tunnel' (or ipsec-transport) and bind ipsec_profile"
+      add_terminations: "After creating the tunnel, add create_tunnel_termination for each side with role peer/hub/spoke"
+    create_l2vpn:
+      identifier_range: "identifier is the L2VPN-wide ID (e.g. VNI for VXLAN). Per-type recommended ranges in NetBox docs."
+      bind_terminations: "Add l2vpn-terminations to attach VLANs, interfaces, or VRFs to the L2VPN service"
+    create_ike_policy:
+      proposals_order: "proposals is ordered: first match wins during IKE negotiation"
+      preshared_key: "preshared_key is stored encrypted; only readable by users with auth.view_token permission"
+    create_event_rule:
+      action_target: "action_object_type + action_object_id point at the target: extras.webhook for HTTP callbacks, extras.script for scripts, extras.notificationgroup for in-app notifications"
+      conditions_dsl: "conditions is JSON DSL: {and: [{attr: 'status', value: 'active'}, ...]}"
+    run_script:
+      job_polling: "Returns a Job object with id; poll /core/jobs/{id}/ until status is 'completed', 'errored', or 'failed'"
+      commit: "commit=false runs a dry-run that rolls back DB changes -- useful for validation"
+    sync_data_source:
+      async: "Returns immediately with a job ID; sync runs in the background. Watch /core/jobs/{id}/ to see status."
+    create_webhook:
+      decoupled: "NetBox 4.0+ decoupled webhooks from triggers. Webhooks now only define HTTP delivery -- bind to events via event-rules."
+      body_template: "Custom Jinja2 body templates use {{ event }}, {{ model }}, {{ data }}, {{ snapshots }}, {{ username }}, {{ request_id }}"
+    create_token:
+      one_shot_key: "The 'key' field is returned ONLY on the create response. Save it immediately; subsequent GETs do not return it."
+      bootstrap: "provision_token (POST /users/tokens/provision/) lets a user obtain their first token with username+password"
+    create_contact_assignment:
+      polymorphic: "object_type accepts any model with the ContactsMixin -- e.g. dcim.device, dcim.rack, circuits.circuit, virtualization.virtualmachine, ipam.prefix"
+    get_rack_elevation:
+      svg: "?render=svg returns image/svg+xml; default is application/json. ?face=rear shows the rear face."
+    get_connected_device:
+      params_required: "Both peer_device (name) and peer_interface (name) must be supplied; returns 404 if not connected via cable"
 
   tools:
 
@@ -341,6 +481,69 @@ backend:
       pagination: none
 
     # =========================================================================
+    # DCIM -- Site Groups
+    # =========================================================================
+
+    list_site_groups:
+      method: GET
+      path: /dcim/site-groups/
+      access: read
+      description: "List site groups (hierarchical grouping of sites, orthogonal to regions)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        parent: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_site_group:
+      method: GET
+      path: /dcim/site-groups/{id}/
+      access: read
+      description: "Get a specific site group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_site_group:
+      method: POST
+      path: /dcim/site-groups/
+      access: write
+      description: "Create a site group"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        parent: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_site_group:
+      method: PATCH
+      path: /dcim/site-groups/{id}/
+      access: write
+      description: "Update a site group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        parent: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_site_group:
+      method: DELETE
+      path: /dcim/site-groups/{id}/
+      access: dangerous
+      description: "Delete a site group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
     # DCIM -- Racks
     # =========================================================================
 
@@ -413,6 +616,240 @@ backend:
       path: /dcim/racks/{id}/
       access: dangerous
       description: "Delete a rack"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_rack_elevation:
+      method: GET
+      path: /dcim/racks/{id}/elevation/
+      access: read
+      description: >
+        Get rack elevation -- returns the rack units with installed devices.
+        Use ?render=svg for a graphical SVG rendering, default is JSON list of units.
+      params:
+        id: { type: integer, in: path, required: true }
+        face: { type: string, in: query, description: "front (default) or rear" }
+        render: { type: string, in: query, description: "json (default) or svg" }
+        unit_width: { type: integer, in: query }
+        unit_height: { type: integer, in: query }
+        legend_width: { type: integer, in: query }
+        exclude: { type: integer, in: query, description: "Device ID to exclude" }
+        expand_devices: { type: boolean, in: query }
+        include_images: { type: boolean, in: query }
+      pagination: none
+
+    # =========================================================================
+    # DCIM -- Rack Roles, Types & Reservations
+    # =========================================================================
+
+    list_rack_roles:
+      method: GET
+      path: /dcim/rack-roles/
+      access: read
+      description: "List rack roles (functional classification of racks)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_rack_role:
+      method: GET
+      path: /dcim/rack-roles/{id}/
+      access: read
+      description: "Get a specific rack role"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_rack_role:
+      method: POST
+      path: /dcim/rack-roles/
+      access: write
+      description: "Create a rack role"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        color: { type: string, in: body, description: "6-char hex color" }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_rack_role:
+      method: PATCH
+      path: /dcim/rack-roles/{id}/
+      access: write
+      description: "Update a rack role"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        color: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_rack_role:
+      method: DELETE
+      path: /dcim/rack-roles/{id}/
+      access: dangerous
+      description: "Delete a rack role"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_rack_types:
+      method: GET
+      path: /dcim/rack-types/
+      access: read
+      description: "List rack types (reusable rack model definitions, NetBox 4.1+)"
+      params:
+        model: { type: string, in: query }
+        slug: { type: string, in: query }
+        manufacturer: { type: string, in: query }
+        manufacturer_id: { type: integer, in: query }
+        form_factor: { type: string, in: query, description: "2-post-frame, 4-post-frame, 4-post-cabinet, wall-frame, wall-cabinet" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_rack_type:
+      method: GET
+      path: /dcim/rack-types/{id}/
+      access: read
+      description: "Get a specific rack type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_rack_type:
+      method: POST
+      path: /dcim/rack-types/
+      access: write
+      description: "Create a rack type"
+      params:
+        manufacturer: { type: integer, in: body, required: true }
+        model: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        form_factor: { type: string, in: body, description: "2-post-frame, 4-post-frame, 4-post-cabinet, wall-frame, wall-cabinet" }
+        width: { type: integer, in: body, description: "Width in inches (10, 19, 21, 23)" }
+        u_height: { type: integer, in: body, description: "Default rack height in units" }
+        starting_unit: { type: integer, in: body }
+        desc_units: { type: boolean, in: body, description: "Numbering descending from top" }
+        outer_width: { type: integer, in: body }
+        outer_depth: { type: integer, in: body }
+        outer_unit: { type: string, in: body, description: "mm or in" }
+        weight: { type: number, in: body }
+        max_weight: { type: integer, in: body }
+        weight_unit: { type: string, in: body, description: "kg, g, lb, oz" }
+        mounting_depth: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_rack_type:
+      method: PATCH
+      path: /dcim/rack-types/{id}/
+      access: write
+      description: "Update a rack type"
+      params:
+        id: { type: integer, in: path, required: true }
+        manufacturer: { type: integer, in: body }
+        model: { type: string, in: body }
+        slug: { type: string, in: body }
+        form_factor: { type: string, in: body }
+        width: { type: integer, in: body }
+        u_height: { type: integer, in: body }
+        starting_unit: { type: integer, in: body }
+        desc_units: { type: boolean, in: body }
+        outer_width: { type: integer, in: body }
+        outer_depth: { type: integer, in: body }
+        outer_unit: { type: string, in: body }
+        weight: { type: number, in: body }
+        max_weight: { type: integer, in: body }
+        weight_unit: { type: string, in: body }
+        mounting_depth: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_rack_type:
+      method: DELETE
+      path: /dcim/rack-types/{id}/
+      access: dangerous
+      description: "Delete a rack type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_rack_reservations:
+      method: GET
+      path: /dcim/rack-reservations/
+      access: read
+      description: "List rack reservations (claimed rack units for future use)"
+      params:
+        rack: { type: integer, in: query }
+        rack_id: { type: integer, in: query }
+        site: { type: string, in: query }
+        user: { type: string, in: query }
+        tenant: { type: string, in: query }
+        tag: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_rack_reservation:
+      method: GET
+      path: /dcim/rack-reservations/{id}/
+      access: read
+      description: "Get a specific rack reservation"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_rack_reservation:
+      method: POST
+      path: /dcim/rack-reservations/
+      access: write
+      description: "Reserve rack units for future installation"
+      params:
+        rack: { type: integer, in: body, required: true }
+        units: { type: array, in: body, required: true, description: "Array of unit numbers (e.g. [1,2,3,4])" }
+        user: { type: integer, in: body, required: true, description: "User ID who owns the reservation" }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body, required: true }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_rack_reservation:
+      method: PATCH
+      path: /dcim/rack-reservations/{id}/
+      access: write
+      description: "Update a rack reservation"
+      params:
+        id: { type: integer, in: path, required: true }
+        rack: { type: integer, in: body }
+        units: { type: array, in: body }
+        user: { type: integer, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_rack_reservation:
+      method: DELETE
+      path: /dcim/rack-reservations/{id}/
+      access: dangerous
+      description: "Delete a rack reservation"
       params:
         id: { type: integer, in: path, required: true }
       pagination: none
@@ -751,6 +1188,609 @@ backend:
       pagination: none
 
     # =========================================================================
+    # DCIM -- Modules & Module Types
+    # =========================================================================
+
+    list_module_types:
+      method: GET
+      path: /dcim/module-types/
+      access: read
+      description: "List module types (reusable hardware module definitions, e.g. line cards)"
+      params:
+        manufacturer: { type: string, in: query }
+        manufacturer_id: { type: integer, in: query }
+        model: { type: string, in: query }
+        part_number: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_module_type:
+      method: GET
+      path: /dcim/module-types/{id}/
+      access: read
+      description: "Get a specific module type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_module_type:
+      method: POST
+      path: /dcim/module-types/
+      access: write
+      description: "Create a module type"
+      params:
+        manufacturer: { type: integer, in: body, required: true }
+        model: { type: string, in: body, required: true }
+        part_number: { type: string, in: body }
+        airflow: { type: string, in: body, description: "front-to-rear, rear-to-front, left-to-right, right-to-left, side-to-rear, passive, mixed" }
+        weight: { type: number, in: body }
+        weight_unit: { type: string, in: body }
+        profile: { type: integer, in: body, description: "Module type profile ID" }
+        attributes: { type: object, in: body, description: "Profile-specific attributes as key-value object" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_module_type:
+      method: PATCH
+      path: /dcim/module-types/{id}/
+      access: write
+      description: "Update a module type"
+      params:
+        id: { type: integer, in: path, required: true }
+        manufacturer: { type: integer, in: body }
+        model: { type: string, in: body }
+        part_number: { type: string, in: body }
+        airflow: { type: string, in: body }
+        weight: { type: number, in: body }
+        weight_unit: { type: string, in: body }
+        profile: { type: integer, in: body }
+        attributes: { type: object, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_module_type:
+      method: DELETE
+      path: /dcim/module-types/{id}/
+      access: dangerous
+      description: "Delete a module type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_module_type_profiles:
+      method: GET
+      path: /dcim/module-type-profiles/
+      access: read
+      description: "List module type profiles (schemas for module-type custom attributes, NetBox 4.3+)"
+      params:
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_module_type_profile:
+      method: GET
+      path: /dcim/module-type-profiles/{id}/
+      access: read
+      description: "Get a specific module type profile"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_module_type_profile:
+      method: POST
+      path: /dcim/module-type-profiles/
+      access: admin
+      description: "Create a module type profile (JSON Schema describing module-type attributes)"
+      params:
+        name: { type: string, in: body, required: true }
+        schema: { type: object, in: body, description: "JSON Schema for the profile's attributes" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_module_type_profile:
+      method: PATCH
+      path: /dcim/module-type-profiles/{id}/
+      access: admin
+      description: "Update a module type profile"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        schema: { type: object, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_module_type_profile:
+      method: DELETE
+      path: /dcim/module-type-profiles/{id}/
+      access: dangerous
+      description: "Delete a module type profile"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_modules:
+      method: GET
+      path: /dcim/modules/
+      access: read
+      description: "List installed modules (instances of module-types mounted in module-bays)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        module_bay: { type: string, in: query }
+        module_bay_id: { type: integer, in: query }
+        module_type: { type: string, in: query }
+        module_type_id: { type: integer, in: query }
+        serial: { type: string, in: query }
+        status: { type: string, in: query, description: "offline, active, planned, staged, side-loaded, faulty, decommissioning" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_module:
+      method: GET
+      path: /dcim/modules/{id}/
+      access: read
+      description: "Get a specific module"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_module:
+      method: POST
+      path: /dcim/modules/
+      access: write
+      description: "Install a module into a module bay"
+      params:
+        device: { type: integer, in: body, required: true }
+        module_bay: { type: integer, in: body, required: true }
+        module_type: { type: integer, in: body, required: true }
+        status: { type: string, in: body, description: "offline, active, planned, staged, side-loaded, faulty, decommissioning" }
+        serial: { type: string, in: body }
+        asset_tag: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_module:
+      method: PATCH
+      path: /dcim/modules/{id}/
+      access: write
+      description: "Update a module"
+      params:
+        id: { type: integer, in: path, required: true }
+        device: { type: integer, in: body }
+        module_bay: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        status: { type: string, in: body }
+        serial: { type: string, in: body }
+        asset_tag: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_module:
+      method: DELETE
+      path: /dcim/modules/{id}/
+      access: dangerous
+      description: "Delete a module"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_module_bays:
+      method: GET
+      path: /dcim/module-bays/
+      access: read
+      description: "List module bays (slots on a device that accept modules)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_module_bay:
+      method: GET
+      path: /dcim/module-bays/{id}/
+      access: read
+      description: "Get a specific module bay"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_module_bay:
+      method: POST
+      path: /dcim/module-bays/
+      access: write
+      description: "Create a module bay on a device"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        position: { type: string, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_module_bay:
+      method: PATCH
+      path: /dcim/module-bays/{id}/
+      access: write
+      description: "Update a module bay"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        position: { type: string, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_module_bay:
+      method: DELETE
+      path: /dcim/module-bays/{id}/
+      access: dangerous
+      description: "Delete a module bay"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # DCIM -- Device Bays, Virtual Chassis & Inventory
+    # =========================================================================
+
+    list_device_bays:
+      method: GET
+      path: /dcim/device-bays/
+      access: read
+      description: "List device bays (slots that contain child devices, e.g. blade chassis)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_device_bay:
+      method: GET
+      path: /dcim/device-bays/{id}/
+      access: read
+      description: "Get a specific device bay"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_device_bay:
+      method: POST
+      path: /dcim/device-bays/
+      access: write
+      description: "Create a device bay"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        installed_device: { type: integer, in: body, description: "Child device ID to install in this bay" }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_device_bay:
+      method: PATCH
+      path: /dcim/device-bays/{id}/
+      access: write
+      description: "Update a device bay"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        installed_device: { type: integer, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_device_bay:
+      method: DELETE
+      path: /dcim/device-bays/{id}/
+      access: dangerous
+      description: "Delete a device bay"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_virtual_chassis:
+      method: GET
+      path: /dcim/virtual-chassis/
+      access: read
+      description: "List virtual chassis (logical grouping of stacked devices that share a single management plane)"
+      params:
+        name: { type: string, in: query }
+        domain: { type: string, in: query }
+        master: { type: string, in: query }
+        master_id: { type: integer, in: query }
+        tag: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_virtual_chassis:
+      method: GET
+      path: /dcim/virtual-chassis/{id}/
+      access: read
+      description: "Get a specific virtual chassis"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_virtual_chassis:
+      method: POST
+      path: /dcim/virtual-chassis/
+      access: write
+      description: "Create a virtual chassis. Assign devices via PATCH /dcim/devices/ to set virtual_chassis and vc_position fields."
+      params:
+        name: { type: string, in: body, required: true }
+        domain: { type: string, in: body }
+        master: { type: integer, in: body, description: "ID of the device that is the chassis master" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_virtual_chassis:
+      method: PATCH
+      path: /dcim/virtual-chassis/{id}/
+      access: write
+      description: "Update a virtual chassis"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        domain: { type: string, in: body }
+        master: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_virtual_chassis:
+      method: DELETE
+      path: /dcim/virtual-chassis/{id}/
+      access: dangerous
+      description: "Delete a virtual chassis"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_virtual_device_contexts:
+      method: GET
+      path: /dcim/virtual-device-contexts/
+      access: read
+      description: "List virtual device contexts (VDCs -- multiple logical contexts on one physical device, e.g. Cisco Nexus VDCs)"
+      params:
+        name: { type: string, in: query }
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        status: { type: string, in: query }
+        tag: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_virtual_device_context:
+      method: GET
+      path: /dcim/virtual-device-contexts/{id}/
+      access: read
+      description: "Get a specific VDC"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_virtual_device_context:
+      method: POST
+      path: /dcim/virtual-device-contexts/
+      access: write
+      description: "Create a virtual device context"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        identifier: { type: integer, in: body, description: "Numeric VDC identifier" }
+        status: { type: string, in: body, description: "active, planned, offline" }
+        tenant: { type: integer, in: body }
+        primary_ip4: { type: integer, in: body }
+        primary_ip6: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_virtual_device_context:
+      method: PATCH
+      path: /dcim/virtual-device-contexts/{id}/
+      access: write
+      description: "Update a virtual device context"
+      params:
+        id: { type: integer, in: path, required: true }
+        device: { type: integer, in: body }
+        name: { type: string, in: body }
+        identifier: { type: integer, in: body }
+        status: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        primary_ip4: { type: integer, in: body }
+        primary_ip6: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_virtual_device_context:
+      method: DELETE
+      path: /dcim/virtual-device-contexts/{id}/
+      access: dangerous
+      description: "Delete a virtual device context"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_inventory_items:
+      method: GET
+      path: /dcim/inventory-items/
+      access: read
+      description: "List inventory items (line cards, fans, PSUs not modeled as full modules)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        manufacturer: { type: string, in: query }
+        serial: { type: string, in: query }
+        asset_tag: { type: string, in: query }
+        discovered: { type: boolean, in: query }
+        parent_id: { type: integer, in: query }
+        role: { type: string, in: query }
+        tag: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_inventory_item:
+      method: GET
+      path: /dcim/inventory-items/{id}/
+      access: read
+      description: "Get a specific inventory item"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_inventory_item:
+      method: POST
+      path: /dcim/inventory-items/
+      access: write
+      description: "Create an inventory item on a device"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        parent: { type: integer, in: body, description: "Parent inventory item for hierarchical items" }
+        role: { type: integer, in: body, description: "Inventory item role ID" }
+        manufacturer: { type: integer, in: body }
+        part_id: { type: string, in: body }
+        serial: { type: string, in: body }
+        asset_tag: { type: string, in: body }
+        discovered: { type: boolean, in: body }
+        component_type: { type: string, in: body, description: "ContentType, e.g. dcim.interface" }
+        component_id: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_inventory_item:
+      method: PATCH
+      path: /dcim/inventory-items/{id}/
+      access: write
+      description: "Update an inventory item"
+      params:
+        id: { type: integer, in: path, required: true }
+        device: { type: integer, in: body }
+        name: { type: string, in: body }
+        parent: { type: integer, in: body }
+        role: { type: integer, in: body }
+        manufacturer: { type: integer, in: body }
+        part_id: { type: string, in: body }
+        serial: { type: string, in: body }
+        asset_tag: { type: string, in: body }
+        discovered: { type: boolean, in: body }
+        component_type: { type: string, in: body }
+        component_id: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_inventory_item:
+      method: DELETE
+      path: /dcim/inventory-items/{id}/
+      access: dangerous
+      description: "Delete an inventory item"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_inventory_item_roles:
+      method: GET
+      path: /dcim/inventory-item-roles/
+      access: read
+      description: "List inventory item roles (functional classification, e.g. CPU, PSU, Fan)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_inventory_item_role:
+      method: GET
+      path: /dcim/inventory-item-roles/{id}/
+      access: read
+      description: "Get a specific inventory item role"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_inventory_item_role:
+      method: POST
+      path: /dcim/inventory-item-roles/
+      access: write
+      description: "Create an inventory item role"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        color: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_inventory_item_role:
+      method: PATCH
+      path: /dcim/inventory-item-roles/{id}/
+      access: write
+      description: "Update an inventory item role"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        color: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_inventory_item_role:
+      method: DELETE
+      path: /dcim/inventory-item-roles/{id}/
+      access: dangerous
+      description: "Delete an inventory item role"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
     # DCIM -- Interfaces & Cables
     # =========================================================================
 
@@ -805,6 +1845,7 @@ backend:
         mode: { type: string, in: body, description: "access, tagged, tagged-all" }
         untagged_vlan: { type: integer, in: body }
         tagged_vlans: { type: array, in: body }
+        wireless_lans: { type: array, in: body, description: "Array of wireless_lan IDs (M2M). Empty array detaches all." }
         tags: { type: array, in: body }
       pagination: none
 
@@ -812,7 +1853,11 @@ backend:
       method: PATCH
       path: /dcim/interfaces/{id}/
       access: write
-      description: "Update a device interface"
+      description: >
+        Update a device interface. Nullable foreign keys and choice fields accept
+        an explicit JSON null to clear -- omitting the field leaves it unchanged.
+        Nullable params: untagged_vlan, lag, parent, bridge, vrf, primary_mac_address,
+        mode, duplex. For M2M wireless_lans / tagged_vlans / tags pass [] to detach all.
       params:
         id: { type: integer, in: path, required: true }
         name: { type: string, in: body }
@@ -820,19 +1865,20 @@ backend:
         enabled: { type: boolean, in: body }
         mtu: { type: integer, in: body }
         mac_address: { type: string, in: body, description: "MAC address (e.g. 00:1A:2B:3C:4D:5E)" }
-        primary_mac_address: { type: integer, in: body, description: "Primary MAC address object ID (Netbox 4.x)" }
+        primary_mac_address: { type: integer, in: body, description: "Primary MAC address object ID (Netbox 4.x). Nullable: pass null to clear." }
         mgmt_only: { type: boolean, in: body, description: "Management-only interface" }
         label: { type: string, in: body, description: "Physical label" }
         speed: { type: integer, in: body, description: "Speed in Kbps" }
-        duplex: { type: string, in: body, description: "half, full, auto" }
-        parent: { type: integer, in: body, description: "Parent interface ID" }
-        bridge: { type: integer, in: body, description: "Bridge interface ID" }
-        lag: { type: integer, in: body, description: "LAG interface ID" }
-        vrf: { type: integer, in: body, description: "VRF assignment" }
+        duplex: { type: string, in: body, description: "half, full, auto. Nullable: pass null to clear." }
+        parent: { type: integer, in: body, description: "Parent interface ID. Nullable: pass null to clear." }
+        bridge: { type: integer, in: body, description: "Bridge interface ID. Nullable: pass null to clear." }
+        lag: { type: integer, in: body, description: "LAG interface ID. Nullable: pass null to clear." }
+        vrf: { type: integer, in: body, description: "VRF assignment. Nullable: pass null to clear." }
         description: { type: string, in: body }
-        mode: { type: string, in: body }
-        untagged_vlan: { type: integer, in: body }
-        tagged_vlans: { type: array, in: body }
+        mode: { type: string, in: body, description: "access, tagged, tagged-all. Nullable: pass null to clear (unsets trunk mode)." }
+        untagged_vlan: { type: integer, in: body, description: "Untagged native VLAN ID. Nullable: pass null to clear." }
+        tagged_vlans: { type: array, in: body, description: "Array of VLAN IDs allowed when mode is tagged. Pass [] to detach all." }
+        wireless_lans: { type: array, in: body, description: "Array of wireless_lan IDs (M2M). Pass [] to detach all." }
         tags: { type: array, in: body }
       pagination: none
 
@@ -1018,6 +2064,1014 @@ backend:
       path: /dcim/mac-addresses/{id}/
       access: dangerous
       description: "Delete a MAC address entry"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # DCIM -- Front/Rear/Console-Server Ports & Power Outlets
+    # =========================================================================
+
+    get_console_port:
+      method: GET
+      path: /dcim/console-ports/{id}/
+      access: read
+      description: "Get a specific console port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_console_port:
+      method: PATCH
+      path: /dcim/console-ports/{id}/
+      access: write
+      description: "Update a console port"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        speed: { type: integer, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_console_port:
+      method: DELETE
+      path: /dcim/console-ports/{id}/
+      access: dangerous
+      description: "Delete a console port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    trace_console_port:
+      method: GET
+      path: /dcim/console-ports/{id}/trace/
+      access: read
+      description: "Trace the cable path from this console port to its far end (returns a list of cable segments)"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_console_server_ports:
+      method: GET
+      path: /dcim/console-server-ports/
+      access: read
+      description: "List console server ports (the server-side of console connections)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        type: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_console_server_port:
+      method: GET
+      path: /dcim/console-server-ports/{id}/
+      access: read
+      description: "Get a specific console server port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_console_server_port:
+      method: POST
+      path: /dcim/console-server-ports/
+      access: write
+      description: "Create a console server port"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, description: "de-9, db-25, rj-45, usb-a, usb-c, other" }
+        speed: { type: integer, in: body, description: "Baud rate (e.g. 9600, 115200)" }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_console_server_port:
+      method: PATCH
+      path: /dcim/console-server-ports/{id}/
+      access: write
+      description: "Update a console server port"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        speed: { type: integer, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_console_server_port:
+      method: DELETE
+      path: /dcim/console-server-ports/{id}/
+      access: dangerous
+      description: "Delete a console server port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_power_port:
+      method: GET
+      path: /dcim/power-ports/{id}/
+      access: read
+      description: "Get a specific power port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_power_port:
+      method: PATCH
+      path: /dcim/power-ports/{id}/
+      access: write
+      description: "Update a power port"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        maximum_draw: { type: integer, in: body }
+        allocated_draw: { type: integer, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_power_port:
+      method: DELETE
+      path: /dcim/power-ports/{id}/
+      access: dangerous
+      description: "Delete a power port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_power_outlets:
+      method: GET
+      path: /dcim/power-outlets/
+      access: read
+      description: "List power outlets (sockets on a PDU or device that supply power to other devices)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        type: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_power_outlet:
+      method: GET
+      path: /dcim/power-outlets/{id}/
+      access: read
+      description: "Get a specific power outlet"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_power_outlet:
+      method: POST
+      path: /dcim/power-outlets/
+      access: write
+      description: "Create a power outlet (typically on a PDU)"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, description: "iec-60320-c5, iec-60320-c7, iec-60320-c13, iec-60320-c15, iec-60320-c19, iec-60320-c21, nema-1-15r, nema-5-15r, etc." }
+        power_port: { type: integer, in: body, description: "Upstream power port that feeds this outlet" }
+        feed_leg: { type: string, in: body, description: "A, B, or C (for multi-phase power)" }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_power_outlet:
+      method: PATCH
+      path: /dcim/power-outlets/{id}/
+      access: write
+      description: "Update a power outlet"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        power_port: { type: integer, in: body }
+        feed_leg: { type: string, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_power_outlet:
+      method: DELETE
+      path: /dcim/power-outlets/{id}/
+      access: dangerous
+      description: "Delete a power outlet"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_front_ports:
+      method: GET
+      path: /dcim/front-ports/
+      access: read
+      description: "List front ports (patch panel front-side ports, paired with rear ports)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        type: { type: string, in: query }
+        rear_port: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_front_port:
+      method: GET
+      path: /dcim/front-ports/{id}/
+      access: read
+      description: "Get a specific front port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_front_port:
+      method: POST
+      path: /dcim/front-ports/
+      access: write
+      description: "Create a front port on a patch panel (must reference a rear port)"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, required: true, description: "8p8c, 8p6c, 8p4c, 8p2c, 6p6c, 6p4c, 6p2c, 4p4c, 4p2c, gg45, tera-4p, tera-2p, tera-1p, 110-punch, bnc, f, n, mrj21, fc, lc, lc-pc, lc-upc, lc-apc, lsh, lsh-pc, lsh-upc, lsh-apc, lx5, lx5-pc, lx5-upc, lx5-apc, mpo, mtrj, sc, sc-pc, sc-upc, sc-apc, st, cs, sn, sma-905, sma-906, urm-p2, urm-p4, urm-p8, splice, other" }
+        color: { type: string, in: body }
+        rear_port: { type: integer, in: body, required: true }
+        rear_port_position: { type: integer, in: body, default: 1 }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_front_port:
+      method: PATCH
+      path: /dcim/front-ports/{id}/
+      access: write
+      description: "Update a front port"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        color: { type: string, in: body }
+        rear_port: { type: integer, in: body }
+        rear_port_position: { type: integer, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_front_port:
+      method: DELETE
+      path: /dcim/front-ports/{id}/
+      access: dangerous
+      description: "Delete a front port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    paths_front_port:
+      method: GET
+      path: /dcim/front-ports/{id}/paths/
+      access: read
+      description: "List all cable paths that pass through this front port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_rear_ports:
+      method: GET
+      path: /dcim/rear-ports/
+      access: read
+      description: "List rear ports (patch panel rear-side ports, cabled to trunk lines)"
+      params:
+        device: { type: string, in: query }
+        device_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        type: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_rear_port:
+      method: GET
+      path: /dcim/rear-ports/{id}/
+      access: read
+      description: "Get a specific rear port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_rear_port:
+      method: POST
+      path: /dcim/rear-ports/
+      access: write
+      description: "Create a rear port on a patch panel"
+      params:
+        device: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, required: true, description: "Connector type (see front-port types)" }
+        color: { type: string, in: body }
+        positions: { type: integer, in: body, default: 1, description: "Number of front-port positions this rear port supports" }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_rear_port:
+      method: PATCH
+      path: /dcim/rear-ports/{id}/
+      access: write
+      description: "Update a rear port"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        color: { type: string, in: body }
+        positions: { type: integer, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        mark_connected: { type: boolean, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_rear_port:
+      method: DELETE
+      path: /dcim/rear-ports/{id}/
+      access: dangerous
+      description: "Delete a rear port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    paths_rear_port:
+      method: GET
+      path: /dcim/rear-ports/{id}/paths/
+      access: read
+      description: "List all cable paths that pass through this rear port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    trace_interface:
+      method: GET
+      path: /dcim/interfaces/{id}/trace/
+      access: read
+      description: "Trace the cable path from this interface to its far end"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    trace_power_port:
+      method: GET
+      path: /dcim/power-ports/{id}/trace/
+      access: read
+      description: "Trace the cable path from this power port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    trace_power_outlet:
+      method: GET
+      path: /dcim/power-outlets/{id}/trace/
+      access: read
+      description: "Trace the cable path from this power outlet"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    trace_console_server_port:
+      method: GET
+      path: /dcim/console-server-ports/{id}/trace/
+      access: read
+      description: "Trace the cable path from this console server port"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_connected_device:
+      method: GET
+      path: /dcim/connected-device/
+      access: read
+      description: >
+        Lookup the device connected to a given peer device/interface.
+        Returns the device at the far end of the cable, or 404 if not connected.
+      params:
+        peer_device: { type: string, in: query, required: true }
+        peer_interface: { type: string, in: query, required: true }
+      pagination: none
+
+    list_cable_terminations:
+      method: GET
+      path: /dcim/cable-terminations/
+      access: read
+      description: "List cable terminations (endpoints of cables -- the join between a cable and a port)"
+      params:
+        cable: { type: integer, in: query }
+        cable_id: { type: integer, in: query }
+        cable_end: { type: string, in: query, description: "A or B" }
+        termination_type: { type: string, in: query }
+        termination_id: { type: integer, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_cable_termination:
+      method: GET
+      path: /dcim/cable-terminations/{id}/
+      access: read
+      description: "Get a specific cable termination"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # DCIM -- Power Panels & Feeds
+    # =========================================================================
+
+    list_power_panels:
+      method: GET
+      path: /dcim/power-panels/
+      access: read
+      description: "List power panels (the upstream source of power feeds at a site)"
+      params:
+        site: { type: string, in: query }
+        site_id: { type: integer, in: query }
+        location: { type: string, in: query }
+        location_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_power_panel:
+      method: GET
+      path: /dcim/power-panels/{id}/
+      access: read
+      description: "Get a specific power panel"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_power_panel:
+      method: POST
+      path: /dcim/power-panels/
+      access: write
+      description: "Create a power panel"
+      params:
+        site: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        location: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_power_panel:
+      method: PATCH
+      path: /dcim/power-panels/{id}/
+      access: write
+      description: "Update a power panel"
+      params:
+        id: { type: integer, in: path, required: true }
+        site: { type: integer, in: body }
+        name: { type: string, in: body }
+        location: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_power_panel:
+      method: DELETE
+      path: /dcim/power-panels/{id}/
+      access: dangerous
+      description: "Delete a power panel"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_power_feeds:
+      method: GET
+      path: /dcim/power-feeds/
+      access: read
+      description: "List power feeds (the circuit from a power panel that supplies a rack)"
+      params:
+        power_panel: { type: integer, in: query }
+        power_panel_id: { type: integer, in: query }
+        rack: { type: integer, in: query }
+        rack_id: { type: integer, in: query }
+        site: { type: string, in: query }
+        name: { type: string, in: query }
+        status: { type: string, in: query, description: "offline, active, planned, failed" }
+        type: { type: string, in: query, description: "primary, redundant" }
+        supply: { type: string, in: query, description: "ac, dc" }
+        phase: { type: string, in: query, description: "single-phase, three-phase" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_power_feed:
+      method: GET
+      path: /dcim/power-feeds/{id}/
+      access: read
+      description: "Get a specific power feed"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_power_feed:
+      method: POST
+      path: /dcim/power-feeds/
+      access: write
+      description: "Create a power feed (circuit from a power panel to a rack)"
+      params:
+        power_panel: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        rack: { type: integer, in: body }
+        status: { type: string, in: body, description: "offline, active, planned, failed" }
+        type: { type: string, in: body, description: "primary, redundant" }
+        supply: { type: string, in: body, description: "ac, dc" }
+        phase: { type: string, in: body, description: "single-phase, three-phase" }
+        voltage: { type: integer, in: body, description: "Volts (negative for DC -- e.g. -48)" }
+        amperage: { type: integer, in: body }
+        max_utilization: { type: integer, in: body, description: "Maximum utilization percent (1-100)" }
+        mark_connected: { type: boolean, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_power_feed:
+      method: PATCH
+      path: /dcim/power-feeds/{id}/
+      access: write
+      description: "Update a power feed"
+      params:
+        id: { type: integer, in: path, required: true }
+        power_panel: { type: integer, in: body }
+        rack: { type: integer, in: body }
+        name: { type: string, in: body }
+        status: { type: string, in: body }
+        type: { type: string, in: body }
+        supply: { type: string, in: body }
+        phase: { type: string, in: body }
+        voltage: { type: integer, in: body }
+        amperage: { type: integer, in: body }
+        max_utilization: { type: integer, in: body }
+        mark_connected: { type: boolean, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_power_feed:
+      method: DELETE
+      path: /dcim/power-feeds/{id}/
+      access: dangerous
+      description: "Delete a power feed"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    trace_power_feed:
+      method: GET
+      path: /dcim/power-feeds/{id}/trace/
+      access: read
+      description: "Trace the cable path from this power feed"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # DCIM -- Component Templates
+    # =========================================================================
+    # Templates define the components that are auto-created when a device-type
+    # or module-type is instantiated. Each template type mirrors its concrete
+    # component (interface-templates -> interfaces, etc.).
+    # All templates share the pattern: scoped to device_type OR module_type,
+    # with name/label/type/description fields. Use list + create only -- updates
+    # are uncommon (typical workflow is delete + recreate).
+
+    list_interface_templates:
+      method: GET
+      path: /dcim/interface-templates/
+      access: read
+      description: "List interface templates on device-types and module-types"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        type: { type: string, in: query }
+        q: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_interface_template:
+      method: POST
+      path: /dcim/interface-templates/
+      access: write
+      description: "Create an interface template. Must specify device_type OR module_type."
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, required: true, description: "e.g. 1000base-t, 10gbase-x-sfpp, 25gbase-x-sfp28, 100gbase-x-qsfp28" }
+        enabled: { type: boolean, in: body, default: true }
+        mgmt_only: { type: boolean, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        poe_mode: { type: string, in: body, description: "pd or pse" }
+        poe_type: { type: string, in: body }
+        rf_role: { type: string, in: body }
+        bridge: { type: integer, in: body }
+      pagination: none
+
+    get_interface_template:
+      method: GET
+      path: /dcim/interface-templates/{id}/
+      access: read
+      description: "Get a specific interface template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_interface_template:
+      method: PATCH
+      path: /dcim/interface-templates/{id}/
+      access: write
+      description: "Update an interface template"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        enabled: { type: boolean, in: body }
+        mgmt_only: { type: boolean, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+        poe_mode: { type: string, in: body }
+        poe_type: { type: string, in: body }
+      pagination: none
+
+    delete_interface_template:
+      method: DELETE
+      path: /dcim/interface-templates/{id}/
+      access: dangerous
+      description: "Delete an interface template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_console_port_templates:
+      method: GET
+      path: /dcim/console-port-templates/
+      access: read
+      description: "List console port templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_console_port_template:
+      method: POST
+      path: /dcim/console-port-templates/
+      access: write
+      description: "Create a console port template"
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_console_port_template:
+      method: DELETE
+      path: /dcim/console-port-templates/{id}/
+      access: dangerous
+      description: "Delete a console port template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_console_server_port_templates:
+      method: GET
+      path: /dcim/console-server-port-templates/
+      access: read
+      description: "List console server port templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_console_server_port_template:
+      method: POST
+      path: /dcim/console-server-port-templates/
+      access: write
+      description: "Create a console server port template"
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_console_server_port_template:
+      method: DELETE
+      path: /dcim/console-server-port-templates/{id}/
+      access: dangerous
+      description: "Delete a console server port template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_power_port_templates:
+      method: GET
+      path: /dcim/power-port-templates/
+      access: read
+      description: "List power port templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_power_port_template:
+      method: POST
+      path: /dcim/power-port-templates/
+      access: write
+      description: "Create a power port template"
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body }
+        maximum_draw: { type: integer, in: body }
+        allocated_draw: { type: integer, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_power_port_template:
+      method: DELETE
+      path: /dcim/power-port-templates/{id}/
+      access: dangerous
+      description: "Delete a power port template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_power_outlet_templates:
+      method: GET
+      path: /dcim/power-outlet-templates/
+      access: read
+      description: "List power outlet templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_power_outlet_template:
+      method: POST
+      path: /dcim/power-outlet-templates/
+      access: write
+      description: "Create a power outlet template"
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body }
+        power_port: { type: integer, in: body, description: "Power port template ID (upstream)" }
+        feed_leg: { type: string, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_power_outlet_template:
+      method: DELETE
+      path: /dcim/power-outlet-templates/{id}/
+      access: dangerous
+      description: "Delete a power outlet template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_front_port_templates:
+      method: GET
+      path: /dcim/front-port-templates/
+      access: read
+      description: "List front port templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_front_port_template:
+      method: POST
+      path: /dcim/front-port-templates/
+      access: write
+      description: "Create a front port template (must reference a rear-port-template)"
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, required: true }
+        color: { type: string, in: body }
+        rear_port: { type: integer, in: body, required: true, description: "Rear port template ID" }
+        rear_port_position: { type: integer, in: body, default: 1 }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_front_port_template:
+      method: DELETE
+      path: /dcim/front-port-templates/{id}/
+      access: dangerous
+      description: "Delete a front port template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_rear_port_templates:
+      method: GET
+      path: /dcim/rear-port-templates/
+      access: read
+      description: "List rear port templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_rear_port_template:
+      method: POST
+      path: /dcim/rear-port-templates/
+      access: write
+      description: "Create a rear port template"
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body }
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, required: true }
+        color: { type: string, in: body }
+        positions: { type: integer, in: body, default: 1 }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_rear_port_template:
+      method: DELETE
+      path: /dcim/rear-port-templates/{id}/
+      access: dangerous
+      description: "Delete a rear port template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_module_bay_templates:
+      method: GET
+      path: /dcim/module-bay-templates/
+      access: read
+      description: "List module bay templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        moduletype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_module_bay_template:
+      method: POST
+      path: /dcim/module-bay-templates/
+      access: write
+      description: "Create a module bay template"
+      params:
+        device_type: { type: integer, in: body }
+        module_type: { type: integer, in: body, description: "Parent module type for nested module bays" }
+        name: { type: string, in: body, required: true }
+        position: { type: string, in: body }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_module_bay_template:
+      method: DELETE
+      path: /dcim/module-bay-templates/{id}/
+      access: dangerous
+      description: "Delete a module bay template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_device_bay_templates:
+      method: GET
+      path: /dcim/device-bay-templates/
+      access: read
+      description: "List device bay templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_device_bay_template:
+      method: POST
+      path: /dcim/device-bay-templates/
+      access: write
+      description: "Create a device bay template"
+      params:
+        device_type: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        label: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_device_bay_template:
+      method: DELETE
+      path: /dcim/device-bay-templates/{id}/
+      access: dangerous
+      description: "Delete a device bay template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_inventory_item_templates:
+      method: GET
+      path: /dcim/inventory-item-templates/
+      access: read
+      description: "List inventory item templates"
+      params:
+        devicetype_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        role: { type: string, in: query }
+        manufacturer: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    create_inventory_item_template:
+      method: POST
+      path: /dcim/inventory-item-templates/
+      access: write
+      description: "Create an inventory item template"
+      params:
+        device_type: { type: integer, in: body, required: true }
+        parent: { type: integer, in: body, description: "Parent inventory item template" }
+        name: { type: string, in: body, required: true }
+        label: { type: string, in: body }
+        role: { type: integer, in: body }
+        manufacturer: { type: integer, in: body }
+        part_id: { type: string, in: body }
+        description: { type: string, in: body }
+        component_type: { type: string, in: body }
+        component_id: { type: integer, in: body }
+      pagination: none
+
+    delete_inventory_item_template:
+      method: DELETE
+      path: /dcim/inventory-item-templates/{id}/
+      access: dangerous
+      description: "Delete an inventory item template"
       params:
         id: { type: integer, in: path, required: true }
       pagination: none
@@ -1596,6 +3650,526 @@ backend:
         id: { type: integer, in: path, required: true }
       pagination: none
 
+    list_service_templates:
+      method: GET
+      path: /ipam/service-templates/
+      access: read
+      description: "List service templates (reusable service definitions, e.g. 'web-https')"
+      params:
+        name: { type: string, in: query }
+        protocol: { type: string, in: query }
+        port: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_service_template:
+      method: GET
+      path: /ipam/service-templates/{id}/
+      access: read
+      description: "Get a specific service template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_service_template:
+      method: POST
+      path: /ipam/service-templates/
+      access: write
+      description: "Create a service template"
+      params:
+        name: { type: string, in: body, required: true }
+        protocol: { type: string, in: body, required: true, description: "tcp, udp, sctp" }
+        ports: { type: array, in: body, required: true, description: "List of port numbers, e.g. [80, 443]" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_service_template:
+      method: PATCH
+      path: /ipam/service-templates/{id}/
+      access: write
+      description: "Update a service template"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        protocol: { type: string, in: body }
+        ports: { type: array, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_service_template:
+      method: DELETE
+      path: /ipam/service-templates/{id}/
+      access: dangerous
+      description: "Delete a service template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_route_targets:
+      method: GET
+      path: /ipam/route-targets/
+      access: read
+      description: "List BGP route targets (e.g. '65000:100', used for MPLS L3VPN import/export)"
+      params:
+        name: { type: string, in: query }
+        tenant: { type: string, in: query }
+        importing_vrf_id: { type: integer, in: query }
+        exporting_vrf_id: { type: integer, in: query }
+        tag: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_route_target:
+      method: GET
+      path: /ipam/route-targets/{id}/
+      access: read
+      description: "Get a specific route target"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_route_target:
+      method: POST
+      path: /ipam/route-targets/
+      access: write
+      description: "Create a route target. Assign to VRFs via vrf.import_targets / vrf.export_targets."
+      params:
+        name: { type: string, in: body, required: true, description: "Route target name (e.g. '65000:100')" }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_route_target:
+      method: PATCH
+      path: /ipam/route-targets/{id}/
+      access: write
+      description: "Update a route target"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_route_target:
+      method: DELETE
+      path: /ipam/route-targets/{id}/
+      access: dangerous
+      description: "Delete a route target"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_asn_ranges:
+      method: GET
+      path: /ipam/asn-ranges/
+      access: read
+      description: "List ASN ranges (bounded ASN allocation pools)"
+      params:
+        name: { type: string, in: query }
+        rir: { type: string, in: query }
+        tenant: { type: string, in: query }
+        tag: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_asn_range:
+      method: GET
+      path: /ipam/asn-ranges/{id}/
+      access: read
+      description: "Get a specific ASN range"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_asn_range:
+      method: POST
+      path: /ipam/asn-ranges/
+      access: write
+      description: "Create an ASN range"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        rir: { type: integer, in: body, required: true }
+        start: { type: integer, in: body, required: true }
+        end: { type: integer, in: body, required: true }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_asn_range:
+      method: PATCH
+      path: /ipam/asn-ranges/{id}/
+      access: write
+      description: "Update an ASN range"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        rir: { type: integer, in: body }
+        start: { type: integer, in: body }
+        end: { type: integer, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_asn_range:
+      method: DELETE
+      path: /ipam/asn-ranges/{id}/
+      access: dangerous
+      description: "Delete an ASN range"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_available_asns:
+      method: GET
+      path: /ipam/asn-ranges/{id}/available-asns/
+      access: read
+      description: "List the next unallocated ASNs within a range. POST to the same path to claim ASNs."
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    claim_asn:
+      method: POST
+      path: /ipam/asn-ranges/{id}/available-asns/
+      access: write
+      description: "Claim the next available ASN from a range and assign metadata"
+      params:
+        id: { type: integer, in: path, required: true }
+        description: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    list_available_prefixes:
+      method: GET
+      path: /ipam/prefixes/{id}/available-prefixes/
+      access: read
+      description: "List unallocated sub-prefixes within a prefix"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    claim_prefix:
+      method: POST
+      path: /ipam/prefixes/{id}/available-prefixes/
+      access: write
+      description: "Carve a new child prefix out of a parent. NetBox picks the next free block of prefix_length."
+      params:
+        id: { type: integer, in: path, required: true }
+        prefix_length: { type: integer, in: body, required: true, description: "Mask length for the new child prefix (e.g. 26)" }
+        status: { type: string, in: body }
+        site: { type: integer, in: body }
+        vrf: { type: integer, in: body }
+        tenant: { type: integer, in: body }
+        role: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    list_available_ips_in_range:
+      method: GET
+      path: /ipam/ip-ranges/{id}/available-ips/
+      access: read
+      description: "List free IPs within an IP range"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_available_vlans:
+      method: GET
+      path: /ipam/vlan-groups/{id}/available-vlans/
+      access: read
+      description: "List the next unallocated VIDs in a VLAN group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    claim_vlan:
+      method: POST
+      path: /ipam/vlan-groups/{id}/available-vlans/
+      access: write
+      description: "Claim the next available VID from a VLAN group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body, required: true }
+        status: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        role: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    get_ip_range:
+      method: GET
+      path: /ipam/ip-ranges/{id}/
+      access: read
+      description: "Get a specific IP range"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_ip_range:
+      method: PATCH
+      path: /ipam/ip-ranges/{id}/
+      access: write
+      description: "Update an IP range"
+      params:
+        id: { type: integer, in: path, required: true }
+        start_address: { type: string, in: body }
+        end_address: { type: string, in: body }
+        vrf: { type: integer, in: body }
+        status: { type: string, in: body }
+        role: { type: integer, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_ip_range:
+      method: DELETE
+      path: /ipam/ip-ranges/{id}/
+      access: dangerous
+      description: "Delete an IP range"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_aggregate:
+      method: GET
+      path: /ipam/aggregates/{id}/
+      access: read
+      description: "Get a specific aggregate"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_aggregate:
+      method: PATCH
+      path: /ipam/aggregates/{id}/
+      access: write
+      description: "Update an aggregate"
+      params:
+        id: { type: integer, in: path, required: true }
+        prefix: { type: string, in: body }
+        rir: { type: integer, in: body }
+        tenant: { type: integer, in: body }
+        date_added: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_aggregate:
+      method: DELETE
+      path: /ipam/aggregates/{id}/
+      access: dangerous
+      description: "Delete an aggregate"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_asn:
+      method: GET
+      path: /ipam/asns/{id}/
+      access: read
+      description: "Get a specific ASN"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_asn:
+      method: PATCH
+      path: /ipam/asns/{id}/
+      access: write
+      description: "Update an ASN"
+      params:
+        id: { type: integer, in: path, required: true }
+        asn: { type: integer, in: body }
+        rir: { type: integer, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_asn:
+      method: DELETE
+      path: /ipam/asns/{id}/
+      access: dangerous
+      description: "Delete an ASN"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_rir:
+      method: GET
+      path: /ipam/rirs/{id}/
+      access: read
+      description: "Get a specific RIR (Regional Internet Registry, e.g. RIPE, ARIN)"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_rir:
+      method: PATCH
+      path: /ipam/rirs/{id}/
+      access: write
+      description: "Update a RIR"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        is_private: { type: boolean, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_rir:
+      method: DELETE
+      path: /ipam/rirs/{id}/
+      access: dangerous
+      description: "Delete a RIR"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # IPAM -- VLAN Translations
+    # =========================================================================
+
+    list_vlan_translation_policies:
+      method: GET
+      path: /ipam/vlan-translation-policies/
+      access: read
+      description: "List VLAN translation policies (named sets of 1:1 VID mappings, NetBox 4.0+)"
+      params:
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_vlan_translation_policy:
+      method: GET
+      path: /ipam/vlan-translation-policies/{id}/
+      access: read
+      description: "Get a specific VLAN translation policy"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_vlan_translation_policy:
+      method: POST
+      path: /ipam/vlan-translation-policies/
+      access: write
+      description: "Create a VLAN translation policy"
+      params:
+        name: { type: string, in: body, required: true }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_vlan_translation_policy:
+      method: PATCH
+      path: /ipam/vlan-translation-policies/{id}/
+      access: write
+      description: "Update a VLAN translation policy"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_vlan_translation_policy:
+      method: DELETE
+      path: /ipam/vlan-translation-policies/{id}/
+      access: dangerous
+      description: "Delete a VLAN translation policy"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_vlan_translation_rules:
+      method: GET
+      path: /ipam/vlan-translation-rules/
+      access: read
+      description: "List VLAN translation rules (individual local-VID to remote-VID mappings within a policy)"
+      params:
+        policy: { type: integer, in: query }
+        policy_id: { type: integer, in: query }
+        local_vid: { type: integer, in: query }
+        remote_vid: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_vlan_translation_rule:
+      method: GET
+      path: /ipam/vlan-translation-rules/{id}/
+      access: read
+      description: "Get a specific VLAN translation rule"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_vlan_translation_rule:
+      method: POST
+      path: /ipam/vlan-translation-rules/
+      access: write
+      description: "Create a VLAN translation rule"
+      params:
+        policy: { type: integer, in: body, required: true }
+        local_vid: { type: integer, in: body, required: true }
+        remote_vid: { type: integer, in: body, required: true }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_vlan_translation_rule:
+      method: PATCH
+      path: /ipam/vlan-translation-rules/{id}/
+      access: write
+      description: "Update a VLAN translation rule"
+      params:
+        id: { type: integer, in: path, required: true }
+        policy: { type: integer, in: body }
+        local_vid: { type: integer, in: body }
+        remote_vid: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_vlan_translation_rule:
+      method: DELETE
+      path: /ipam/vlan-translation-rules/{id}/
+      access: dangerous
+      description: "Delete a VLAN translation rule"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
     # =========================================================================
     # IPAM -- FHRP Groups & Assignments
     # =========================================================================
@@ -2072,6 +4646,100 @@ backend:
         tags: { type: array, in: body }
       pagination: none
 
+    get_virtual_disk:
+      method: GET
+      path: /virtualization/virtual-disks/{id}/
+      access: read
+      description: "Get a specific virtual disk"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_virtual_disk:
+      method: PATCH
+      path: /virtualization/virtual-disks/{id}/
+      access: write
+      description: "Update a virtual disk"
+      params:
+        id: { type: integer, in: path, required: true }
+        virtual_machine: { type: integer, in: body }
+        name: { type: string, in: body }
+        size: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_virtual_disk:
+      method: DELETE
+      path: /virtualization/virtual-disks/{id}/
+      access: dangerous
+      description: "Delete a virtual disk"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_virtual_machine_types:
+      method: GET
+      path: /virtualization/virtual-machine-types/
+      access: read
+      description: "List virtual machine types (NetBox 4.2+, model definitions like AWS EC2 'm5.xlarge')"
+      params:
+        manufacturer: { type: string, in: query }
+        manufacturer_id: { type: integer, in: query }
+        model: { type: string, in: query }
+        slug: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_virtual_machine_type:
+      method: GET
+      path: /virtualization/virtual-machine-types/{id}/
+      access: read
+      description: "Get a specific VM type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_virtual_machine_type:
+      method: POST
+      path: /virtualization/virtual-machine-types/
+      access: write
+      description: "Create a virtual machine type"
+      params:
+        manufacturer: { type: integer, in: body, required: true }
+        model: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_virtual_machine_type:
+      method: PATCH
+      path: /virtualization/virtual-machine-types/{id}/
+      access: write
+      description: "Update a virtual machine type"
+      params:
+        id: { type: integer, in: path, required: true }
+        manufacturer: { type: integer, in: body }
+        model: { type: string, in: body }
+        slug: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_virtual_machine_type:
+      method: DELETE
+      path: /virtualization/virtual-machine-types/{id}/
+      access: dangerous
+      description: "Delete a virtual machine type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
     # =========================================================================
     # TENANCY
     # =========================================================================
@@ -2307,6 +4975,128 @@ backend:
       path: /tenancy/contact-roles/{id}/
       access: dangerous
       description: "Delete a contact role"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_contact_groups:
+      method: GET
+      path: /tenancy/contact-groups/
+      access: read
+      description: "List contact groups (hierarchical grouping of contacts)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        parent: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_contact_group:
+      method: GET
+      path: /tenancy/contact-groups/{id}/
+      access: read
+      description: "Get a specific contact group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_contact_group:
+      method: POST
+      path: /tenancy/contact-groups/
+      access: write
+      description: "Create a contact group"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        parent: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_contact_group:
+      method: PATCH
+      path: /tenancy/contact-groups/{id}/
+      access: write
+      description: "Update a contact group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        parent: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_contact_group:
+      method: DELETE
+      path: /tenancy/contact-groups/{id}/
+      access: dangerous
+      description: "Delete a contact group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_contact_assignments:
+      method: GET
+      path: /tenancy/contact-assignments/
+      access: read
+      description: "List contact assignments (links between contacts and any NetBox object)"
+      params:
+        object_type: { type: string, in: query, description: "e.g. dcim.device, ipam.prefix, circuits.circuit" }
+        object_id: { type: integer, in: query }
+        contact: { type: integer, in: query }
+        contact_id: { type: integer, in: query }
+        role: { type: integer, in: query }
+        role_id: { type: integer, in: query }
+        priority: { type: string, in: query, description: "primary, secondary, tertiary, inactive" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_contact_assignment:
+      method: GET
+      path: /tenancy/contact-assignments/{id}/
+      access: read
+      description: "Get a specific contact assignment"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_contact_assignment:
+      method: POST
+      path: /tenancy/contact-assignments/
+      access: write
+      description: "Assign a contact to an object (device, circuit, etc.)"
+      params:
+        object_type: { type: string, in: body, required: true, description: "e.g. dcim.device, circuits.circuit" }
+        object_id: { type: integer, in: body, required: true }
+        contact: { type: integer, in: body, required: true }
+        role: { type: integer, in: body }
+        priority: { type: string, in: body, description: "primary, secondary, tertiary, inactive" }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_contact_assignment:
+      method: PATCH
+      path: /tenancy/contact-assignments/{id}/
+      access: write
+      description: "Update a contact assignment"
+      params:
+        id: { type: integer, in: path, required: true }
+        contact: { type: integer, in: body }
+        role: { type: integer, in: body }
+        priority: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_contact_assignment:
+      method: DELETE
+      path: /tenancy/contact-assignments/{id}/
+      access: dangerous
+      description: "Delete a contact assignment"
       params:
         id: { type: integer, in: path, required: true }
       pagination: none
@@ -2557,9 +5347,508 @@ backend:
         id: { type: integer, in: path, required: true }
       pagination: none
 
+    paths_circuit_termination:
+      method: GET
+      path: /circuits/circuit-terminations/{id}/paths/
+      access: read
+      description: "Trace cable paths from a circuit termination"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_provider_accounts:
+      method: GET
+      path: /circuits/provider-accounts/
+      access: read
+      description: "List provider accounts (a customer's account number with a provider)"
+      params:
+        name: { type: string, in: query }
+        account: { type: string, in: query }
+        provider: { type: string, in: query }
+        provider_id: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_provider_account:
+      method: GET
+      path: /circuits/provider-accounts/{id}/
+      access: read
+      description: "Get a specific provider account"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_provider_account:
+      method: POST
+      path: /circuits/provider-accounts/
+      access: write
+      description: "Create a provider account"
+      params:
+        provider: { type: integer, in: body, required: true }
+        name: { type: string, in: body }
+        account: { type: string, in: body, required: true }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_provider_account:
+      method: PATCH
+      path: /circuits/provider-accounts/{id}/
+      access: write
+      description: "Update a provider account"
+      params:
+        id: { type: integer, in: path, required: true }
+        provider: { type: integer, in: body }
+        name: { type: string, in: body }
+        account: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_provider_account:
+      method: DELETE
+      path: /circuits/provider-accounts/{id}/
+      access: dangerous
+      description: "Delete a provider account"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_provider_networks:
+      method: GET
+      path: /circuits/provider-networks/
+      access: read
+      description: "List provider networks (the far end of a circuit -- a provider's MPLS cloud, peering fabric, etc.)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        provider: { type: string, in: query }
+        provider_id: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_provider_network:
+      method: GET
+      path: /circuits/provider-networks/{id}/
+      access: read
+      description: "Get a specific provider network"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_provider_network:
+      method: POST
+      path: /circuits/provider-networks/
+      access: write
+      description: "Create a provider network"
+      params:
+        provider: { type: integer, in: body, required: true }
+        name: { type: string, in: body, required: true }
+        service_id: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_provider_network:
+      method: PATCH
+      path: /circuits/provider-networks/{id}/
+      access: write
+      description: "Update a provider network"
+      params:
+        id: { type: integer, in: path, required: true }
+        provider: { type: integer, in: body }
+        name: { type: string, in: body }
+        service_id: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_provider_network:
+      method: DELETE
+      path: /circuits/provider-networks/{id}/
+      access: dangerous
+      description: "Delete a provider network"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_circuit_groups:
+      method: GET
+      path: /circuits/circuit-groups/
+      access: read
+      description: "List circuit groups (logical grouping of related circuits, e.g. SD-WAN underlays)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_circuit_group:
+      method: GET
+      path: /circuits/circuit-groups/{id}/
+      access: read
+      description: "Get a specific circuit group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_circuit_group:
+      method: POST
+      path: /circuits/circuit-groups/
+      access: write
+      description: "Create a circuit group"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_circuit_group:
+      method: PATCH
+      path: /circuits/circuit-groups/{id}/
+      access: write
+      description: "Update a circuit group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_circuit_group:
+      method: DELETE
+      path: /circuits/circuit-groups/{id}/
+      access: dangerous
+      description: "Delete a circuit group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_circuit_group_assignments:
+      method: GET
+      path: /circuits/circuit-group-assignments/
+      access: read
+      description: "List circuit-to-group assignments with priorities"
+      params:
+        group: { type: integer, in: query }
+        group_id: { type: integer, in: query }
+        member_type: { type: string, in: query, description: "e.g. circuits.circuit, circuits.virtualcircuit" }
+        member_id: { type: integer, in: query }
+        priority: { type: string, in: query, description: "primary, secondary, tertiary, inactive" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_circuit_group_assignment:
+      method: GET
+      path: /circuits/circuit-group-assignments/{id}/
+      access: read
+      description: "Get a specific circuit group assignment"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_circuit_group_assignment:
+      method: POST
+      path: /circuits/circuit-group-assignments/
+      access: write
+      description: "Assign a circuit (or virtual circuit) to a circuit group"
+      params:
+        group: { type: integer, in: body, required: true }
+        member_type: { type: string, in: body, required: true, description: "circuits.circuit or circuits.virtualcircuit" }
+        member_id: { type: integer, in: body, required: true }
+        priority: { type: string, in: body, description: "primary, secondary, tertiary, inactive" }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_circuit_group_assignment:
+      method: PATCH
+      path: /circuits/circuit-group-assignments/{id}/
+      access: write
+      description: "Update a circuit group assignment"
+      params:
+        id: { type: integer, in: path, required: true }
+        priority: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_circuit_group_assignment:
+      method: DELETE
+      path: /circuits/circuit-group-assignments/{id}/
+      access: dangerous
+      description: "Delete a circuit group assignment"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_virtual_circuit_types:
+      method: GET
+      path: /circuits/virtual-circuit-types/
+      access: read
+      description: "List virtual circuit types (classification of virtual circuits, NetBox 4.2+)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_virtual_circuit_type:
+      method: GET
+      path: /circuits/virtual-circuit-types/{id}/
+      access: read
+      description: "Get a specific virtual circuit type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_virtual_circuit_type:
+      method: POST
+      path: /circuits/virtual-circuit-types/
+      access: write
+      description: "Create a virtual circuit type"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        color: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_virtual_circuit_type:
+      method: PATCH
+      path: /circuits/virtual-circuit-types/{id}/
+      access: write
+      description: "Update a virtual circuit type"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        color: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_virtual_circuit_type:
+      method: DELETE
+      path: /circuits/virtual-circuit-types/{id}/
+      access: dangerous
+      description: "Delete a virtual circuit type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_virtual_circuits:
+      method: GET
+      path: /circuits/virtual-circuits/
+      access: read
+      description: "List virtual circuits (logical end-to-end paths that run over a provider network, NetBox 4.2+)"
+      params:
+        cid: { type: string, in: query }
+        provider_network: { type: string, in: query }
+        provider_network_id: { type: integer, in: query }
+        type: { type: string, in: query }
+        status: { type: string, in: query }
+        tenant: { type: string, in: query }
+        tag: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_virtual_circuit:
+      method: GET
+      path: /circuits/virtual-circuits/{id}/
+      access: read
+      description: "Get a specific virtual circuit"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_virtual_circuit:
+      method: POST
+      path: /circuits/virtual-circuits/
+      access: write
+      description: "Create a virtual circuit"
+      params:
+        cid: { type: string, in: body, required: true, description: "Circuit ID, the provider's reference" }
+        provider_network: { type: integer, in: body, required: true }
+        provider_account: { type: integer, in: body }
+        type: { type: integer, in: body, required: true }
+        status: { type: string, in: body, description: "planned, provisioning, active, offline, deprovisioning, decommissioned" }
+        tenant: { type: integer, in: body }
+        group: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_virtual_circuit:
+      method: PATCH
+      path: /circuits/virtual-circuits/{id}/
+      access: write
+      description: "Update a virtual circuit"
+      params:
+        id: { type: integer, in: path, required: true }
+        cid: { type: string, in: body }
+        provider_network: { type: integer, in: body }
+        provider_account: { type: integer, in: body }
+        type: { type: integer, in: body }
+        status: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        group: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_virtual_circuit:
+      method: DELETE
+      path: /circuits/virtual-circuits/{id}/
+      access: dangerous
+      description: "Delete a virtual circuit"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_virtual_circuit_terminations:
+      method: GET
+      path: /circuits/virtual-circuit-terminations/
+      access: read
+      description: "List virtual circuit terminations (endpoints of virtual circuits on interfaces)"
+      params:
+        virtual_circuit: { type: integer, in: query }
+        virtual_circuit_id: { type: integer, in: query }
+        role: { type: string, in: query, description: "peer, hub, spoke" }
+        interface: { type: integer, in: query }
+        interface_id: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_virtual_circuit_termination:
+      method: GET
+      path: /circuits/virtual-circuit-terminations/{id}/
+      access: read
+      description: "Get a specific virtual circuit termination"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_virtual_circuit_termination:
+      method: POST
+      path: /circuits/virtual-circuit-terminations/
+      access: write
+      description: "Terminate a virtual circuit on a physical interface"
+      params:
+        virtual_circuit: { type: integer, in: body, required: true }
+        role: { type: string, in: body, description: "peer, hub, spoke" }
+        interface: { type: integer, in: body, required: true }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_virtual_circuit_termination:
+      method: PATCH
+      path: /circuits/virtual-circuit-terminations/{id}/
+      access: write
+      description: "Update a virtual circuit termination"
+      params:
+        id: { type: integer, in: path, required: true }
+        role: { type: string, in: body }
+        interface: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_virtual_circuit_termination:
+      method: DELETE
+      path: /circuits/virtual-circuit-terminations/{id}/
+      access: dangerous
+      description: "Delete a virtual circuit termination"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
     # =========================================================================
     # WIRELESS
     # =========================================================================
+
+    list_wireless_lan_groups:
+      method: GET
+      path: /wireless/wireless-lan-groups/
+      access: read
+      description: "List wireless LAN groups (hierarchical grouping of SSIDs)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        parent: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_wireless_lan_group:
+      method: GET
+      path: /wireless/wireless-lan-groups/{id}/
+      access: read
+      description: "Get a specific wireless LAN group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_wireless_lan_group:
+      method: POST
+      path: /wireless/wireless-lan-groups/
+      access: write
+      description: "Create a wireless LAN group"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        parent: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_wireless_lan_group:
+      method: PATCH
+      path: /wireless/wireless-lan-groups/{id}/
+      access: write
+      description: "Update a wireless LAN group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        parent: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_wireless_lan_group:
+      method: DELETE
+      path: /wireless/wireless-lan-groups/{id}/
+      access: dangerous
+      description: "Delete a wireless LAN group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
 
     list_wireless_lans:
       method: GET
@@ -2575,6 +5864,15 @@ backend:
         limit: { type: integer, in: query }
         offset: { type: integer, in: query }
 
+    get_wireless_lan:
+      method: GET
+      path: /wireless/wireless-lans/{id}/
+      access: read
+      description: "Get a specific wireless LAN"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
     create_wireless_lan:
       method: POST
       path: /wireless/wireless-lans/
@@ -2585,10 +5883,46 @@ backend:
         status: { type: string, in: body, description: "active, reserved, disabled" }
         group: { type: integer, in: body }
         vlan: { type: integer, in: body }
+        scope_type: { type: string, in: body, description: "dcim.location, dcim.region, dcim.site, dcim.sitegroup" }
+        scope_id: { type: integer, in: body }
         auth_type: { type: string, in: body, description: "open, wep, wpa-personal, wpa-enterprise" }
+        auth_cipher: { type: string, in: body, description: "auto, tkip, aes" }
+        auth_psk: { type: string, in: body }
         tenant: { type: integer, in: body }
         description: { type: string, in: body }
+        comments: { type: string, in: body }
         tags: { type: array, in: body }
+      pagination: none
+
+    update_wireless_lan:
+      method: PATCH
+      path: /wireless/wireless-lans/{id}/
+      access: write
+      description: "Update a wireless LAN"
+      params:
+        id: { type: integer, in: path, required: true }
+        ssid: { type: string, in: body }
+        status: { type: string, in: body }
+        group: { type: integer, in: body }
+        vlan: { type: integer, in: body }
+        scope_type: { type: string, in: body }
+        scope_id: { type: integer, in: body }
+        auth_type: { type: string, in: body }
+        auth_cipher: { type: string, in: body }
+        auth_psk: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_wireless_lan:
+      method: DELETE
+      path: /wireless/wireless-lans/{id}/
+      access: dangerous
+      description: "Delete a wireless LAN"
+      params:
+        id: { type: integer, in: path, required: true }
       pagination: none
 
     list_wireless_links:
@@ -2603,6 +5937,15 @@ backend:
         limit: { type: integer, in: query }
         offset: { type: integer, in: query }
 
+    get_wireless_link:
+      method: GET
+      path: /wireless/wireless-links/{id}/
+      access: read
+      description: "Get a specific wireless link"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
     create_wireless_link:
       method: POST
       path: /wireless/wireless-links/
@@ -2613,13 +5956,105 @@ backend:
         interface_b: { type: integer, in: body, required: true }
         ssid: { type: string, in: body }
         status: { type: string, in: body, description: "connected, planned, decommissioning" }
+        auth_type: { type: string, in: body }
+        auth_cipher: { type: string, in: body }
+        auth_psk: { type: string, in: body }
+        distance: { type: number, in: body }
+        distance_unit: { type: string, in: body, description: "km, m, mi, ft" }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_wireless_link:
+      method: PATCH
+      path: /wireless/wireless-links/{id}/
+      access: write
+      description: "Update a wireless link"
+      params:
+        id: { type: integer, in: path, required: true }
+        ssid: { type: string, in: body }
+        status: { type: string, in: body }
+        auth_type: { type: string, in: body }
+        auth_cipher: { type: string, in: body }
+        auth_psk: { type: string, in: body }
+        distance: { type: number, in: body }
+        distance_unit: { type: string, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_wireless_link:
+      method: DELETE
+      path: /wireless/wireless-links/{id}/
+      access: dangerous
+      description: "Delete a wireless link"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # VPN -- Tunnels & Tunnel Groups
+    # =========================================================================
+
+    list_tunnel_groups:
+      method: GET
+      path: /vpn/tunnel-groups/
+      access: read
+      description: "List tunnel groups (logical grouping of VPN tunnels)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_tunnel_group:
+      method: GET
+      path: /vpn/tunnel-groups/{id}/
+      access: read
+      description: "Get a specific tunnel group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_tunnel_group:
+      method: POST
+      path: /vpn/tunnel-groups/
+      access: write
+      description: "Create a tunnel group"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
         description: { type: string, in: body }
         tags: { type: array, in: body }
       pagination: none
 
-    # =========================================================================
-    # VPN
-    # =========================================================================
+    update_tunnel_group:
+      method: PATCH
+      path: /vpn/tunnel-groups/{id}/
+      access: write
+      description: "Update a tunnel group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_tunnel_group:
+      method: DELETE
+      path: /vpn/tunnel-groups/{id}/
+      access: dangerous
+      description: "Delete a tunnel group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
 
     list_tunnels:
       method: GET
@@ -2628,12 +6063,26 @@ backend:
       description: "List VPN tunnels"
       params:
         name: { type: string, in: query }
-        status: { type: string, in: query }
+        status: { type: string, in: query, description: "planned, active, disabled" }
         group: { type: string, in: query }
+        group_id: { type: integer, in: query }
+        encapsulation: { type: string, in: query }
+        ipsec_profile: { type: string, in: query }
+        ipsec_profile_id: { type: integer, in: query }
         tag: { type: string, in: query }
         q: { type: string, in: query }
+        brief: { type: boolean, in: query }
         limit: { type: integer, in: query }
         offset: { type: integer, in: query }
+
+    get_tunnel:
+      method: GET
+      path: /vpn/tunnels/{id}/
+      access: read
+      description: "Get a specific tunnel"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
 
     create_tunnel:
       method: POST
@@ -2644,24 +6093,462 @@ backend:
         name: { type: string, in: body, required: true }
         status: { type: string, in: body, description: "planned, active, disabled" }
         group: { type: integer, in: body }
-        encapsulation: { type: string, in: body, required: true, description: "ipsec-transport, ipsec-tunnel, ip-ip, gre, wireguard" }
+        encapsulation: { type: string, in: body, required: true, description: "ipsec-transport, ipsec-tunnel, ip-ip, gre, wireguard, openvpn, l2tp, pptp" }
+        ipsec_profile: { type: integer, in: body }
+        tenant: { type: integer, in: body }
         tunnel_id: { type: integer, in: body }
         description: { type: string, in: body }
+        comments: { type: string, in: body }
         tags: { type: array, in: body }
       pagination: none
+
+    update_tunnel:
+      method: PATCH
+      path: /vpn/tunnels/{id}/
+      access: write
+      description: "Update a tunnel"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        status: { type: string, in: body }
+        group: { type: integer, in: body }
+        encapsulation: { type: string, in: body }
+        ipsec_profile: { type: integer, in: body }
+        tenant: { type: integer, in: body }
+        tunnel_id: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_tunnel:
+      method: DELETE
+      path: /vpn/tunnels/{id}/
+      access: dangerous
+      description: "Delete a tunnel"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_tunnel_terminations:
+      method: GET
+      path: /vpn/tunnel-terminations/
+      access: read
+      description: "List tunnel terminations (per-side endpoints of a VPN tunnel)"
+      params:
+        tunnel: { type: integer, in: query }
+        tunnel_id: { type: integer, in: query }
+        role: { type: string, in: query, description: "peer, hub, spoke" }
+        termination_type: { type: string, in: query, description: "dcim.interface, virtualization.vminterface" }
+        termination_id: { type: integer, in: query }
+        outside_ip: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_tunnel_termination:
+      method: GET
+      path: /vpn/tunnel-terminations/{id}/
+      access: read
+      description: "Get a specific tunnel termination"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_tunnel_termination:
+      method: POST
+      path: /vpn/tunnel-terminations/
+      access: write
+      description: "Add a termination to a VPN tunnel"
+      params:
+        tunnel: { type: integer, in: body, required: true }
+        role: { type: string, in: body, required: true, description: "peer, hub, spoke" }
+        termination_type: { type: string, in: body, required: true, description: "dcim.interface or virtualization.vminterface" }
+        termination_id: { type: integer, in: body, required: true }
+        outside_ip: { type: integer, in: body, description: "Outside (public) IP address ID" }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_tunnel_termination:
+      method: PATCH
+      path: /vpn/tunnel-terminations/{id}/
+      access: write
+      description: "Update a tunnel termination"
+      params:
+        id: { type: integer, in: path, required: true }
+        role: { type: string, in: body }
+        termination_type: { type: string, in: body }
+        termination_id: { type: integer, in: body }
+        outside_ip: { type: integer, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_tunnel_termination:
+      method: DELETE
+      path: /vpn/tunnel-terminations/{id}/
+      access: dangerous
+      description: "Delete a tunnel termination"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # VPN -- IKE & IPSec
+    # =========================================================================
+
+    list_ike_proposals:
+      method: GET
+      path: /vpn/ike-proposals/
+      access: read
+      description: "List IKE proposals (encryption/authentication algorithm bundles for IKE phase 1)"
+      params:
+        name: { type: string, in: query }
+        authentication_method: { type: string, in: query }
+        encryption_algorithm: { type: string, in: query }
+        authentication_algorithm: { type: string, in: query }
+        group: { type: integer, in: query, description: "DH group number" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_ike_proposal:
+      method: GET
+      path: /vpn/ike-proposals/{id}/
+      access: read
+      description: "Get a specific IKE proposal"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_ike_proposal:
+      method: POST
+      path: /vpn/ike-proposals/
+      access: write
+      description: "Create an IKE proposal"
+      params:
+        name: { type: string, in: body, required: true }
+        authentication_method: { type: string, in: body, required: true, description: "preshared-keys, certificates, rsa-signatures, dsa-signatures" }
+        encryption_algorithm: { type: string, in: body, required: true, description: "aes-128-cbc, aes-128-gcm, aes-192-cbc, aes-192-gcm, aes-256-cbc, aes-256-gcm, 3des, des" }
+        authentication_algorithm: { type: string, in: body, required: true, description: "hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512, hmac-md5" }
+        group: { type: integer, in: body, required: true, description: "DH group: 1,2,5,14,15,16,17,18,19,20,21,24" }
+        sa_lifetime: { type: integer, in: body, description: "Security Association lifetime in seconds" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_ike_proposal:
+      method: PATCH
+      path: /vpn/ike-proposals/{id}/
+      access: write
+      description: "Update an IKE proposal"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        authentication_method: { type: string, in: body }
+        encryption_algorithm: { type: string, in: body }
+        authentication_algorithm: { type: string, in: body }
+        group: { type: integer, in: body }
+        sa_lifetime: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_ike_proposal:
+      method: DELETE
+      path: /vpn/ike-proposals/{id}/
+      access: dangerous
+      description: "Delete an IKE proposal"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_ike_policies:
+      method: GET
+      path: /vpn/ike-policies/
+      access: read
+      description: "List IKE policies (named groups of proposals + version + mode)"
+      params:
+        name: { type: string, in: query }
+        version: { type: integer, in: query, description: "1 or 2" }
+        mode: { type: string, in: query, description: "aggressive, main" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_ike_policy:
+      method: GET
+      path: /vpn/ike-policies/{id}/
+      access: read
+      description: "Get a specific IKE policy"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_ike_policy:
+      method: POST
+      path: /vpn/ike-policies/
+      access: write
+      description: "Create an IKE policy"
+      params:
+        name: { type: string, in: body, required: true }
+        version: { type: integer, in: body, required: true, description: "1 or 2" }
+        mode: { type: string, in: body, description: "aggressive, main (required for v1)" }
+        proposals: { type: array, in: body, required: true, description: "Array of IKE proposal IDs" }
+        preshared_key: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_ike_policy:
+      method: PATCH
+      path: /vpn/ike-policies/{id}/
+      access: write
+      description: "Update an IKE policy"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        version: { type: integer, in: body }
+        mode: { type: string, in: body }
+        proposals: { type: array, in: body }
+        preshared_key: { type: string, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_ike_policy:
+      method: DELETE
+      path: /vpn/ike-policies/{id}/
+      access: dangerous
+      description: "Delete an IKE policy"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_ipsec_proposals:
+      method: GET
+      path: /vpn/ipsec-proposals/
+      access: read
+      description: "List IPSec proposals (encryption/auth bundles for IPSec phase 2)"
+      params:
+        name: { type: string, in: query }
+        encryption_algorithm: { type: string, in: query }
+        authentication_algorithm: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_ipsec_proposal:
+      method: GET
+      path: /vpn/ipsec-proposals/{id}/
+      access: read
+      description: "Get a specific IPSec proposal"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_ipsec_proposal:
+      method: POST
+      path: /vpn/ipsec-proposals/
+      access: write
+      description: "Create an IPSec proposal"
+      params:
+        name: { type: string, in: body, required: true }
+        encryption_algorithm: { type: string, in: body, description: "aes-128-cbc, aes-128-gcm, aes-192-cbc, aes-192-gcm, aes-256-cbc, aes-256-gcm, 3des, des" }
+        authentication_algorithm: { type: string, in: body, description: "hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512, hmac-md5" }
+        sa_lifetime_seconds: { type: integer, in: body }
+        sa_lifetime_data: { type: integer, in: body, description: "SA lifetime in kilobytes" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_ipsec_proposal:
+      method: PATCH
+      path: /vpn/ipsec-proposals/{id}/
+      access: write
+      description: "Update an IPSec proposal"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        encryption_algorithm: { type: string, in: body }
+        authentication_algorithm: { type: string, in: body }
+        sa_lifetime_seconds: { type: integer, in: body }
+        sa_lifetime_data: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_ipsec_proposal:
+      method: DELETE
+      path: /vpn/ipsec-proposals/{id}/
+      access: dangerous
+      description: "Delete an IPSec proposal"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_ipsec_policies:
+      method: GET
+      path: /vpn/ipsec-policies/
+      access: read
+      description: "List IPSec policies (named bundles of IPSec proposals + PFS group)"
+      params:
+        name: { type: string, in: query }
+        pfs_group: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_ipsec_policy:
+      method: GET
+      path: /vpn/ipsec-policies/{id}/
+      access: read
+      description: "Get a specific IPSec policy"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_ipsec_policy:
+      method: POST
+      path: /vpn/ipsec-policies/
+      access: write
+      description: "Create an IPSec policy"
+      params:
+        name: { type: string, in: body, required: true }
+        proposals: { type: array, in: body, required: true, description: "Array of IPSec proposal IDs" }
+        pfs_group: { type: integer, in: body, description: "Perfect Forward Secrecy DH group" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_ipsec_policy:
+      method: PATCH
+      path: /vpn/ipsec-policies/{id}/
+      access: write
+      description: "Update an IPSec policy"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        proposals: { type: array, in: body }
+        pfs_group: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_ipsec_policy:
+      method: DELETE
+      path: /vpn/ipsec-policies/{id}/
+      access: dangerous
+      description: "Delete an IPSec policy"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_ipsec_profiles:
+      method: GET
+      path: /vpn/ipsec-profiles/
+      access: read
+      description: "List IPSec profiles (combination of IKE policy + IPSec policy + mode -- attach to a tunnel)"
+      params:
+        name: { type: string, in: query }
+        mode: { type: string, in: query, description: "esp, ah" }
+        ike_policy: { type: integer, in: query }
+        ipsec_policy: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_ipsec_profile:
+      method: GET
+      path: /vpn/ipsec-profiles/{id}/
+      access: read
+      description: "Get a specific IPSec profile"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_ipsec_profile:
+      method: POST
+      path: /vpn/ipsec-profiles/
+      access: write
+      description: "Create an IPSec profile"
+      params:
+        name: { type: string, in: body, required: true }
+        mode: { type: string, in: body, required: true, description: "esp or ah" }
+        ike_policy: { type: integer, in: body, required: true }
+        ipsec_policy: { type: integer, in: body, required: true }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_ipsec_profile:
+      method: PATCH
+      path: /vpn/ipsec-profiles/{id}/
+      access: write
+      description: "Update an IPSec profile"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        mode: { type: string, in: body }
+        ike_policy: { type: integer, in: body }
+        ipsec_policy: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_ipsec_profile:
+      method: DELETE
+      path: /vpn/ipsec-profiles/{id}/
+      access: dangerous
+      description: "Delete an IPSec profile"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # VPN -- L2VPN
+    # =========================================================================
 
     list_l2vpns:
       method: GET
       path: /vpn/l2vpns/
       access: read
-      description: "List L2VPN instances (VPLS, VXLAN, etc.)"
+      description: "List L2VPN instances (VPLS, VXLAN, EVPN, etc.)"
       params:
         name: { type: string, in: query }
+        slug: { type: string, in: query }
         type: { type: string, in: query }
+        identifier: { type: integer, in: query }
+        tenant: { type: string, in: query }
         tag: { type: string, in: query }
         q: { type: string, in: query }
+        brief: { type: boolean, in: query }
         limit: { type: integer, in: query }
         offset: { type: integer, in: query }
+
+    get_l2vpn:
+      method: GET
+      path: /vpn/l2vpns/{id}/
+      access: read
+      description: "Get a specific L2VPN"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
 
     create_l2vpn:
       method: POST
@@ -2671,11 +6558,99 @@ backend:
       params:
         name: { type: string, in: body, required: true }
         slug: { type: string, in: body, required: true }
-        type: { type: string, in: body, required: true, description: "vpls, vxlan, vpws, epl, evpl, ep-lan, evp-lan, ep-tree, evp-tree" }
+        type: { type: string, in: body, required: true, description: "vpws, vpls, vxlan, vxlan-evpn, mpls-evpn, pbb-evpn, epl, evpl, ep-lan, evp-lan, ep-tree, evp-tree" }
         identifier: { type: integer, in: body }
+        import_targets: { type: array, in: body, description: "Array of route-target IDs" }
+        export_targets: { type: array, in: body }
         tenant: { type: integer, in: body }
         description: { type: string, in: body }
+        comments: { type: string, in: body }
         tags: { type: array, in: body }
+      pagination: none
+
+    update_l2vpn:
+      method: PATCH
+      path: /vpn/l2vpns/{id}/
+      access: write
+      description: "Update an L2VPN"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        type: { type: string, in: body }
+        identifier: { type: integer, in: body }
+        import_targets: { type: array, in: body }
+        export_targets: { type: array, in: body }
+        tenant: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_l2vpn:
+      method: DELETE
+      path: /vpn/l2vpns/{id}/
+      access: dangerous
+      description: "Delete an L2VPN"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_l2vpn_terminations:
+      method: GET
+      path: /vpn/l2vpn-terminations/
+      access: read
+      description: "List L2VPN terminations (attachments of VLANs/interfaces/VRFs to an L2VPN)"
+      params:
+        l2vpn: { type: integer, in: query }
+        l2vpn_id: { type: integer, in: query }
+        assigned_object_type: { type: string, in: query }
+        assigned_object_id: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_l2vpn_termination:
+      method: GET
+      path: /vpn/l2vpn-terminations/{id}/
+      access: read
+      description: "Get a specific L2VPN termination"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_l2vpn_termination:
+      method: POST
+      path: /vpn/l2vpn-terminations/
+      access: write
+      description: "Attach an interface, VLAN, or VRF to an L2VPN"
+      params:
+        l2vpn: { type: integer, in: body, required: true }
+        assigned_object_type: { type: string, in: body, required: true, description: "ipam.vlan, dcim.interface, virtualization.vminterface, ipam.vrf" }
+        assigned_object_id: { type: integer, in: body, required: true }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_l2vpn_termination:
+      method: PATCH
+      path: /vpn/l2vpn-terminations/{id}/
+      access: write
+      description: "Update an L2VPN termination"
+      params:
+        id: { type: integer, in: path, required: true }
+        assigned_object_type: { type: string, in: body }
+        assigned_object_id: { type: integer, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_l2vpn_termination:
+      method: DELETE
+      path: /vpn/l2vpn-terminations/{id}/
+      access: dangerous
+      description: "Delete an L2VPN termination"
+      params:
+        id: { type: integer, in: path, required: true }
       pagination: none
 
     # =========================================================================
@@ -2935,16 +6910,1286 @@ backend:
       params:
         name: { type: string, in: body, required: true }
         data: { type: object, in: body, required: true, description: "JSON config data" }
+        weight: { type: integer, in: body }
+        is_active: { type: boolean, in: body }
         regions: { type: array, in: body, description: "Array of region IDs" }
+        site_groups: { type: array, in: body }
         sites: { type: array, in: body, description: "Array of site IDs" }
+        locations: { type: array, in: body }
+        device_types: { type: array, in: body }
         roles: { type: array, in: body, description: "Array of role IDs" }
         platforms: { type: array, in: body, description: "Array of platform IDs" }
+        cluster_types: { type: array, in: body }
         cluster_groups: { type: array, in: body }
         clusters: { type: array, in: body }
+        tenant_groups: { type: array, in: body }
         tenants: { type: array, in: body }
         tags: { type: array, in: body }
         description: { type: string, in: body }
       pagination: none
+
+    get_config_context:
+      method: GET
+      path: /extras/config-contexts/{id}/
+      access: read
+      description: "Get a specific config context"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_config_context:
+      method: PATCH
+      path: /extras/config-contexts/{id}/
+      access: write
+      description: "Update a config context"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        data: { type: object, in: body }
+        weight: { type: integer, in: body }
+        is_active: { type: boolean, in: body }
+        regions: { type: array, in: body }
+        site_groups: { type: array, in: body }
+        sites: { type: array, in: body }
+        locations: { type: array, in: body }
+        device_types: { type: array, in: body }
+        roles: { type: array, in: body }
+        platforms: { type: array, in: body }
+        cluster_types: { type: array, in: body }
+        cluster_groups: { type: array, in: body }
+        clusters: { type: array, in: body }
+        tenant_groups: { type: array, in: body }
+        tenants: { type: array, in: body }
+        tags: { type: array, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_config_context:
+      method: DELETE
+      path: /extras/config-contexts/{id}/
+      access: dangerous
+      description: "Delete a config context"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_journal_entry:
+      method: GET
+      path: /extras/journal-entries/{id}/
+      access: read
+      description: "Get a specific journal entry"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    update_journal_entry:
+      method: PATCH
+      path: /extras/journal-entries/{id}/
+      access: write
+      description: "Update a journal entry"
+      params:
+        id: { type: integer, in: path, required: true }
+        kind: { type: string, in: body, description: "info, success, warning, danger" }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_journal_entry:
+      method: DELETE
+      path: /extras/journal-entries/{id}/
+      access: dangerous
+      description: "Delete a journal entry"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # EXTRAS -- Config Templates
+    # =========================================================================
+
+    list_config_templates:
+      method: GET
+      path: /extras/config-templates/
+      access: read
+      description: "List config templates (Jinja2 templates rendered against config-context data)"
+      params:
+        name: { type: string, in: query }
+        data_source: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_config_template:
+      method: GET
+      path: /extras/config-templates/{id}/
+      access: read
+      description: "Get a specific config template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_config_template:
+      method: POST
+      path: /extras/config-templates/
+      access: write
+      description: "Create a config template"
+      params:
+        name: { type: string, in: body, required: true }
+        template_code: { type: string, in: body, description: "Jinja2 template source -- omit if using data_source" }
+        environment_params: { type: object, in: body, description: "Extra params passed to Jinja2 environment" }
+        data_source: { type: integer, in: body, description: "Sync template from a core data source" }
+        data_file: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_config_template:
+      method: PATCH
+      path: /extras/config-templates/{id}/
+      access: write
+      description: "Update a config template"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        template_code: { type: string, in: body }
+        environment_params: { type: object, in: body }
+        data_source: { type: integer, in: body }
+        data_file: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_config_template:
+      method: DELETE
+      path: /extras/config-templates/{id}/
+      access: dangerous
+      description: "Delete a config template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    render_config_template:
+      method: POST
+      path: /extras/config-templates/{id}/render/
+      access: read
+      description: "Render a config template with the supplied context. Returns text/plain or JSON."
+      params:
+        id: { type: integer, in: path, required: true }
+        context: { type: object, in: body, description: "Override context variables (merged with config-context)" }
+      pagination: none
+
+    # =========================================================================
+    # EXTRAS -- Webhooks & Event Rules
+    # =========================================================================
+
+    list_webhooks:
+      method: GET
+      path: /extras/webhooks/
+      access: read
+      description: "List webhooks (HTTP callbacks that fire on object events)"
+      params:
+        name: { type: string, in: query }
+        payload_url: { type: string, in: query }
+        http_method: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_webhook:
+      method: GET
+      path: /extras/webhooks/{id}/
+      access: read
+      description: "Get a specific webhook"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_webhook:
+      method: POST
+      path: /extras/webhooks/
+      access: admin
+      description: "Create a webhook. Webhooks are now decoupled from triggers -- use event-rules to bind a webhook to a model + event."
+      params:
+        name: { type: string, in: body, required: true }
+        payload_url: { type: string, in: body, required: true }
+        http_method: { type: string, in: body, description: "GET, POST, PUT, PATCH, DELETE" }
+        http_content_type: { type: string, in: body, default: "application/json" }
+        additional_headers: { type: string, in: body, description: "Extra HTTP headers as plain text 'Key: Value' per line" }
+        body_template: { type: string, in: body, description: "Jinja2 template for the request body. Omit to send default JSON." }
+        secret: { type: string, in: body, description: "HMAC secret for X-Hook-Signature header" }
+        ssl_verification: { type: boolean, in: body, default: true }
+        ca_file_path: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_webhook:
+      method: PATCH
+      path: /extras/webhooks/{id}/
+      access: admin
+      description: "Update a webhook"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        payload_url: { type: string, in: body }
+        http_method: { type: string, in: body }
+        http_content_type: { type: string, in: body }
+        additional_headers: { type: string, in: body }
+        body_template: { type: string, in: body }
+        secret: { type: string, in: body }
+        ssl_verification: { type: boolean, in: body }
+        ca_file_path: { type: string, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_webhook:
+      method: DELETE
+      path: /extras/webhooks/{id}/
+      access: dangerous
+      description: "Delete a webhook"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_event_rules:
+      method: GET
+      path: /extras/event-rules/
+      access: read
+      description: "List event rules (binding: model + event type -> action target like webhook or script)"
+      params:
+        name: { type: string, in: query }
+        enabled: { type: boolean, in: query }
+        action_type: { type: string, in: query, description: "webhook, script, notification-group" }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_event_rule:
+      method: GET
+      path: /extras/event-rules/{id}/
+      access: read
+      description: "Get a specific event rule"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_event_rule:
+      method: POST
+      path: /extras/event-rules/
+      access: admin
+      description: "Create an event rule"
+      params:
+        name: { type: string, in: body, required: true }
+        object_types: { type: array, in: body, required: true, description: "Array of content types, e.g. ['dcim.device']" }
+        enabled: { type: boolean, in: body, default: true }
+        event_types: { type: array, in: body, required: true, description: "Array of event types: object_created, object_updated, object_deleted, job_started, job_completed, job_failed, job_errored" }
+        conditions: { type: object, in: body, description: "Optional JSON condition expression for filtering" }
+        action_type: { type: string, in: body, required: true, description: "webhook, script, notification-group" }
+        action_object_type: { type: string, in: body, description: "ContentType of action target, e.g. extras.webhook" }
+        action_object_id: { type: integer, in: body, required: true }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_event_rule:
+      method: PATCH
+      path: /extras/event-rules/{id}/
+      access: admin
+      description: "Update an event rule"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        object_types: { type: array, in: body }
+        enabled: { type: boolean, in: body }
+        event_types: { type: array, in: body }
+        conditions: { type: object, in: body }
+        action_type: { type: string, in: body }
+        action_object_type: { type: string, in: body }
+        action_object_id: { type: integer, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_event_rule:
+      method: DELETE
+      path: /extras/event-rules/{id}/
+      access: dangerous
+      description: "Delete an event rule"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # EXTRAS -- Scripts, Export Templates, Saved Filters, Custom Links
+    # =========================================================================
+
+    list_scripts:
+      method: GET
+      path: /extras/scripts/
+      access: read
+      description: >
+        List installed custom scripts. NetBox 4.0+ merged reports into scripts.
+        Each script has a module + name and is identified by id (or 'module.ClassName' string).
+      params:
+        name: { type: string, in: query }
+        module: { type: string, in: query }
+        is_executable: { type: boolean, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_script:
+      method: GET
+      path: /extras/scripts/{id}/
+      access: read
+      description: "Get script details (parameters schema, module info)"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    run_script:
+      method: POST
+      path: /extras/scripts/{id}/
+      access: admin
+      description: >
+        Execute a custom script. Returns a job ID; poll /core/jobs/{job_id}/ for status.
+        Data must match the script's declared parameters.
+      params:
+        id: { type: integer, in: path, required: true }
+        data: { type: object, in: body, required: true, description: "Script parameter values" }
+        commit: { type: boolean, in: body, default: true, description: "Whether to commit DB changes (true) or dry-run (false)" }
+        schedule_at: { type: string, in: body, description: "ISO datetime to defer execution" }
+        interval: { type: integer, in: body, description: "Run every N minutes (recurring)" }
+      pagination: none
+
+    list_export_templates:
+      method: GET
+      path: /extras/export-templates/
+      access: read
+      description: "List export templates (Jinja2 templates that render lists of objects to CSV/JSON/text)"
+      params:
+        name: { type: string, in: query }
+        object_types: { type: string, in: query }
+        mime_type: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_export_template:
+      method: GET
+      path: /extras/export-templates/{id}/
+      access: read
+      description: "Get a specific export template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_export_template:
+      method: POST
+      path: /extras/export-templates/
+      access: admin
+      description: "Create an export template"
+      params:
+        name: { type: string, in: body, required: true }
+        object_types: { type: array, in: body, required: true, description: "ContentTypes this template applies to" }
+        template_code: { type: string, in: body, description: "Jinja2 template source" }
+        mime_type: { type: string, in: body, description: "Output MIME type, e.g. text/csv" }
+        file_extension: { type: string, in: body }
+        as_attachment: { type: boolean, in: body, default: true }
+        data_source: { type: integer, in: body }
+        data_file: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_export_template:
+      method: PATCH
+      path: /extras/export-templates/{id}/
+      access: admin
+      description: "Update an export template"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        object_types: { type: array, in: body }
+        template_code: { type: string, in: body }
+        mime_type: { type: string, in: body }
+        file_extension: { type: string, in: body }
+        as_attachment: { type: boolean, in: body }
+        data_source: { type: integer, in: body }
+        data_file: { type: integer, in: body }
+        description: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_export_template:
+      method: DELETE
+      path: /extras/export-templates/{id}/
+      access: dangerous
+      description: "Delete an export template"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_saved_filters:
+      method: GET
+      path: /extras/saved-filters/
+      access: read
+      description: "List saved filters (reusable URL query parameter sets per object type)"
+      params:
+        name: { type: string, in: query }
+        slug: { type: string, in: query }
+        object_types: { type: string, in: query }
+        enabled: { type: boolean, in: query }
+        shared: { type: boolean, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_saved_filter:
+      method: GET
+      path: /extras/saved-filters/{id}/
+      access: read
+      description: "Get a specific saved filter"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_saved_filter:
+      method: POST
+      path: /extras/saved-filters/
+      access: write
+      description: "Create a saved filter"
+      params:
+        name: { type: string, in: body, required: true }
+        slug: { type: string, in: body, required: true }
+        object_types: { type: array, in: body, required: true }
+        parameters: { type: object, in: body, required: true, description: "URL query parameter dictionary" }
+        weight: { type: integer, in: body }
+        enabled: { type: boolean, in: body, default: true }
+        shared: { type: boolean, in: body, default: true }
+        user: { type: integer, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    update_saved_filter:
+      method: PATCH
+      path: /extras/saved-filters/{id}/
+      access: write
+      description: "Update a saved filter"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        slug: { type: string, in: body }
+        object_types: { type: array, in: body }
+        parameters: { type: object, in: body }
+        weight: { type: integer, in: body }
+        enabled: { type: boolean, in: body }
+        shared: { type: boolean, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_saved_filter:
+      method: DELETE
+      path: /extras/saved-filters/{id}/
+      access: dangerous
+      description: "Delete a saved filter"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_custom_links:
+      method: GET
+      path: /extras/custom-links/
+      access: read
+      description: "List custom links (extra UI buttons shown on object pages)"
+      params:
+        name: { type: string, in: query }
+        object_types: { type: string, in: query }
+        enabled: { type: boolean, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_custom_link:
+      method: GET
+      path: /extras/custom-links/{id}/
+      access: read
+      description: "Get a specific custom link"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_custom_link:
+      method: POST
+      path: /extras/custom-links/
+      access: admin
+      description: "Create a custom link"
+      params:
+        name: { type: string, in: body, required: true }
+        object_types: { type: array, in: body, required: true }
+        link_text: { type: string, in: body, required: true, description: "Jinja2 template for link text" }
+        link_url: { type: string, in: body, required: true, description: "Jinja2 template for URL" }
+        weight: { type: integer, in: body }
+        group_name: { type: string, in: body, description: "Optional grouping label" }
+        button_class: { type: string, in: body, description: "default, outline-secondary, outline-primary, outline-success, etc." }
+        new_window: { type: boolean, in: body }
+        enabled: { type: boolean, in: body, default: true }
+      pagination: none
+
+    update_custom_link:
+      method: PATCH
+      path: /extras/custom-links/{id}/
+      access: admin
+      description: "Update a custom link"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        object_types: { type: array, in: body }
+        link_text: { type: string, in: body }
+        link_url: { type: string, in: body }
+        weight: { type: integer, in: body }
+        group_name: { type: string, in: body }
+        button_class: { type: string, in: body }
+        new_window: { type: boolean, in: body }
+        enabled: { type: boolean, in: body }
+      pagination: none
+
+    delete_custom_link:
+      method: DELETE
+      path: /extras/custom-links/{id}/
+      access: dangerous
+      description: "Delete a custom link"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    # =========================================================================
+    # EXTRAS -- Bookmarks, Notifications, Images
+    # =========================================================================
+
+    list_bookmarks:
+      method: GET
+      path: /extras/bookmarks/
+      access: read
+      description: "List bookmarks (user-specific bookmarks of NetBox objects)"
+      params:
+        user: { type: integer, in: query }
+        user_id: { type: integer, in: query }
+        object_type: { type: string, in: query }
+        object_id: { type: integer, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_bookmark:
+      method: GET
+      path: /extras/bookmarks/{id}/
+      access: read
+      description: "Get a specific bookmark"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_bookmark:
+      method: POST
+      path: /extras/bookmarks/
+      access: write
+      description: "Create a bookmark"
+      params:
+        object_type: { type: string, in: body, required: true, description: "ContentType label, e.g. 'dcim.device'" }
+        object_id: { type: integer, in: body, required: true }
+        user: { type: integer, in: body, required: true }
+      pagination: none
+
+    delete_bookmark:
+      method: DELETE
+      path: /extras/bookmarks/{id}/
+      access: dangerous
+      description: "Delete a bookmark"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_notifications:
+      method: GET
+      path: /extras/notifications/
+      access: read
+      description: "List notifications (in-app messages for users, NetBox 4.1+)"
+      params:
+        user: { type: integer, in: query }
+        user_id: { type: integer, in: query }
+        read: { type: string, in: query, description: "ISO datetime; null for unread" }
+        event_type: { type: string, in: query }
+        object_type: { type: string, in: query }
+        object_id: { type: integer, in: query }
+        q: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_notification:
+      method: GET
+      path: /extras/notifications/{id}/
+      access: read
+      description: "Get a specific notification"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_notification:
+      method: POST
+      path: /extras/notifications/
+      access: write
+      description: "Create a notification (typically used by automation, not humans)"
+      params:
+        user: { type: integer, in: body, required: true }
+        object_type: { type: string, in: body, required: true }
+        object_id: { type: integer, in: body, required: true }
+        event_type: { type: string, in: body, required: true }
+      pagination: none
+
+    update_notification:
+      method: PATCH
+      path: /extras/notifications/{id}/
+      access: write
+      description: "Mark notification as read by setting 'read' to a datetime"
+      params:
+        id: { type: integer, in: path, required: true }
+        read: { type: string, in: body, description: "ISO datetime when the notification was read" }
+      pagination: none
+
+    delete_notification:
+      method: DELETE
+      path: /extras/notifications/{id}/
+      access: dangerous
+      description: "Delete a notification"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_notification_groups:
+      method: GET
+      path: /extras/notification-groups/
+      access: read
+      description: "List notification groups (sets of users + groups that receive event-rule notifications)"
+      params:
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_notification_group:
+      method: GET
+      path: /extras/notification-groups/{id}/
+      access: read
+      description: "Get a specific notification group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_notification_group:
+      method: POST
+      path: /extras/notification-groups/
+      access: admin
+      description: "Create a notification group"
+      params:
+        name: { type: string, in: body, required: true }
+        description: { type: string, in: body }
+        users: { type: array, in: body, description: "Array of user IDs" }
+        groups: { type: array, in: body, description: "Array of group IDs" }
+      pagination: none
+
+    update_notification_group:
+      method: PATCH
+      path: /extras/notification-groups/{id}/
+      access: admin
+      description: "Update a notification group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        description: { type: string, in: body }
+        users: { type: array, in: body }
+        groups: { type: array, in: body }
+      pagination: none
+
+    delete_notification_group:
+      method: DELETE
+      path: /extras/notification-groups/{id}/
+      access: dangerous
+      description: "Delete a notification group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_subscriptions:
+      method: GET
+      path: /extras/subscriptions/
+      access: read
+      description: "List subscriptions (per-user follow lists for specific objects)"
+      params:
+        user: { type: integer, in: query }
+        user_id: { type: integer, in: query }
+        object_type: { type: string, in: query }
+        object_id: { type: integer, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_subscription:
+      method: GET
+      path: /extras/subscriptions/{id}/
+      access: read
+      description: "Get a specific subscription"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_subscription:
+      method: POST
+      path: /extras/subscriptions/
+      access: write
+      description: "Subscribe a user to events on an object"
+      params:
+        user: { type: integer, in: body, required: true }
+        object_type: { type: string, in: body, required: true }
+        object_id: { type: integer, in: body, required: true }
+      pagination: none
+
+    delete_subscription:
+      method: DELETE
+      path: /extras/subscriptions/{id}/
+      access: dangerous
+      description: "Delete a subscription"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_image_attachments:
+      method: GET
+      path: /extras/image-attachments/
+      access: read
+      description: "List image attachments (rack diagrams, photos, etc. attached to NetBox objects)"
+      params:
+        object_type: { type: string, in: query }
+        object_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_image_attachment:
+      method: GET
+      path: /extras/image-attachments/{id}/
+      access: read
+      description: "Get a specific image attachment"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_image_attachment:
+      method: POST
+      path: /extras/image-attachments/
+      access: write
+      content_type: multipart/form-data
+      description: "Attach an image to an object. Uses multipart/form-data with the image bytes."
+      params:
+        object_type: { type: string, in: body, required: true, description: "e.g. dcim.device, dcim.site, dcim.rack" }
+        object_id: { type: integer, in: body, required: true }
+        name: { type: string, in: body }
+        image: { type: file_url, in: body, required: true, description: "URL of the image to upload" }
+      pagination: none
+
+    update_image_attachment:
+      method: PATCH
+      path: /extras/image-attachments/{id}/
+      access: write
+      description: "Update image attachment metadata (name)"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+      pagination: none
+
+    delete_image_attachment:
+      method: DELETE
+      path: /extras/image-attachments/{id}/
+      access: dangerous
+      description: "Delete an image attachment"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    get_dashboard:
+      method: GET
+      path: /extras/dashboard/
+      access: read
+      description: "Get the current user's dashboard configuration (singleton -- not a list endpoint)"
+      params: {}
+      pagination: none
+
+    update_dashboard:
+      method: PATCH
+      path: /extras/dashboard/
+      access: write
+      description: "Update the current user's dashboard layout"
+      params:
+        layout: { type: array, in: body, description: "Array of widget definitions" }
+        config: { type: object, in: body }
+      pagination: none
+
+    # =========================================================================
+    # USERS -- Users, Groups, Permissions, Tokens
+    # =========================================================================
+
+    list_users:
+      method: GET
+      path: /users/users/
+      access: admin
+      description: "List NetBox users. Admin-only endpoint."
+      params:
+        username: { type: string, in: query }
+        email: { type: string, in: query }
+        first_name: { type: string, in: query }
+        last_name: { type: string, in: query }
+        is_active: { type: boolean, in: query }
+        is_staff: { type: boolean, in: query }
+        is_superuser: { type: boolean, in: query }
+        group: { type: string, in: query }
+        group_id: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_user:
+      method: GET
+      path: /users/users/{id}/
+      access: admin
+      description: "Get a specific user"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_user:
+      method: POST
+      path: /users/users/
+      access: admin
+      description: "Create a NetBox user"
+      params:
+        username: { type: string, in: body, required: true }
+        password: { type: string, in: body, required: true }
+        email: { type: string, in: body }
+        first_name: { type: string, in: body }
+        last_name: { type: string, in: body }
+        is_active: { type: boolean, in: body, default: true }
+        is_staff: { type: boolean, in: body }
+        is_superuser: { type: boolean, in: body }
+        groups: { type: array, in: body, description: "Array of group IDs" }
+      pagination: none
+
+    update_user:
+      method: PATCH
+      path: /users/users/{id}/
+      access: admin
+      description: "Update a user. Passing 'password' resets the password."
+      params:
+        id: { type: integer, in: path, required: true }
+        username: { type: string, in: body }
+        password: { type: string, in: body }
+        email: { type: string, in: body }
+        first_name: { type: string, in: body }
+        last_name: { type: string, in: body }
+        is_active: { type: boolean, in: body }
+        is_staff: { type: boolean, in: body }
+        is_superuser: { type: boolean, in: body }
+        groups: { type: array, in: body }
+      pagination: none
+
+    delete_user:
+      method: DELETE
+      path: /users/users/{id}/
+      access: dangerous
+      description: "Delete a user"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_groups:
+      method: GET
+      path: /users/groups/
+      access: admin
+      description: "List user groups"
+      params:
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_group:
+      method: GET
+      path: /users/groups/{id}/
+      access: admin
+      description: "Get a specific group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_group:
+      method: POST
+      path: /users/groups/
+      access: admin
+      description: "Create a user group"
+      params:
+        name: { type: string, in: body, required: true }
+        description: { type: string, in: body }
+      pagination: none
+
+    update_group:
+      method: PATCH
+      path: /users/groups/{id}/
+      access: admin
+      description: "Update a group"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_group:
+      method: DELETE
+      path: /users/groups/{id}/
+      access: dangerous
+      description: "Delete a group"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_permissions:
+      method: GET
+      path: /users/permissions/
+      access: admin
+      description: "List object permissions (per-model + per-action grants assigned to users/groups)"
+      params:
+        name: { type: string, in: query }
+        enabled: { type: boolean, in: query }
+        object_types: { type: string, in: query }
+        user: { type: integer, in: query }
+        group: { type: integer, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_permission:
+      method: GET
+      path: /users/permissions/{id}/
+      access: admin
+      description: "Get a specific permission"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_permission:
+      method: POST
+      path: /users/permissions/
+      access: admin
+      description: "Create an object permission"
+      params:
+        name: { type: string, in: body, required: true }
+        description: { type: string, in: body }
+        enabled: { type: boolean, in: body, default: true }
+        object_types: { type: array, in: body, required: true }
+        actions: { type: array, in: body, required: true, description: "Array of action names: view, add, change, delete (or custom action names)" }
+        constraints: { type: object, in: body, description: "Optional ORM-style filter for restricting which objects this permission applies to" }
+        users: { type: array, in: body }
+        groups: { type: array, in: body }
+      pagination: none
+
+    update_permission:
+      method: PATCH
+      path: /users/permissions/{id}/
+      access: admin
+      description: "Update a permission"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        description: { type: string, in: body }
+        enabled: { type: boolean, in: body }
+        object_types: { type: array, in: body }
+        actions: { type: array, in: body }
+        constraints: { type: object, in: body }
+        users: { type: array, in: body }
+        groups: { type: array, in: body }
+      pagination: none
+
+    delete_permission:
+      method: DELETE
+      path: /users/permissions/{id}/
+      access: dangerous
+      description: "Delete a permission"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_tokens:
+      method: GET
+      path: /users/tokens/
+      access: admin
+      description: "List API tokens. Admin sees all; regular users see only their own."
+      params:
+        user: { type: string, in: query }
+        user_id: { type: integer, in: query }
+        key: { type: string, in: query }
+        write_enabled: { type: boolean, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_token:
+      method: GET
+      path: /users/tokens/{id}/
+      access: admin
+      description: "Get a specific token (key shown only on create)"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_token:
+      method: POST
+      path: /users/tokens/
+      access: admin
+      description: "Issue a new API token for a user. The 'key' field in the response is shown only once."
+      params:
+        user: { type: integer, in: body, required: true }
+        key: { type: string, in: body, description: "Specific token value (auto-generated if omitted)" }
+        write_enabled: { type: boolean, in: body, default: true }
+        expires: { type: string, in: body, description: "ISO datetime; omit for no expiry" }
+        last_used: { type: string, in: body }
+        allowed_ips: { type: array, in: body, description: "Array of CIDR strings; empty = unrestricted" }
+        description: { type: string, in: body }
+      pagination: none
+
+    update_token:
+      method: PATCH
+      path: /users/tokens/{id}/
+      access: admin
+      description: "Update token metadata (description, expiry, allowed IPs)"
+      params:
+        id: { type: integer, in: path, required: true }
+        write_enabled: { type: boolean, in: body }
+        expires: { type: string, in: body }
+        allowed_ips: { type: array, in: body }
+        description: { type: string, in: body }
+      pagination: none
+
+    delete_token:
+      method: DELETE
+      path: /users/tokens/{id}/
+      access: dangerous
+      description: "Revoke a token"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    provision_token:
+      method: POST
+      path: /users/tokens/provision/
+      access: admin
+      description: >
+        Issue a token by username+password without an existing token.
+        Bootstrap-only endpoint. Returns the new token in the response body.
+      params:
+        username: { type: string, in: body, required: true }
+        password: { type: string, in: body, required: true }
+      pagination: none
+
+    # =========================================================================
+    # CORE -- Data Sources, Jobs, Object Types
+    # =========================================================================
+
+    list_data_sources:
+      method: GET
+      path: /core/data-sources/
+      access: read
+      description: "List core data sources (git/S3/local paths used to sync templates, scripts, contexts)"
+      params:
+        name: { type: string, in: query }
+        type: { type: string, in: query, description: "git, amazon-s3, local" }
+        status: { type: string, in: query, description: "new, queued, syncing, completed, failed" }
+        enabled: { type: boolean, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_data_source:
+      method: GET
+      path: /core/data-sources/{id}/
+      access: read
+      description: "Get a specific data source"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    create_data_source:
+      method: POST
+      path: /core/data-sources/
+      access: admin
+      description: "Create a data source"
+      params:
+        name: { type: string, in: body, required: true }
+        type: { type: string, in: body, required: true, description: "git, amazon-s3, local" }
+        source_url: { type: string, in: body, required: true }
+        enabled: { type: boolean, in: body, default: true }
+        ignore_rules: { type: string, in: body, description: ".gitignore-style rules" }
+        parameters: { type: object, in: body, description: "Type-specific config (e.g. {username, password, branch} for git)" }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    update_data_source:
+      method: PATCH
+      path: /core/data-sources/{id}/
+      access: admin
+      description: "Update a data source"
+      params:
+        id: { type: integer, in: path, required: true }
+        name: { type: string, in: body }
+        type: { type: string, in: body }
+        source_url: { type: string, in: body }
+        enabled: { type: boolean, in: body }
+        ignore_rules: { type: string, in: body }
+        parameters: { type: object, in: body }
+        description: { type: string, in: body }
+        comments: { type: string, in: body }
+        tags: { type: array, in: body }
+      pagination: none
+
+    delete_data_source:
+      method: DELETE
+      path: /core/data-sources/{id}/
+      access: dangerous
+      description: "Delete a data source"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    sync_data_source:
+      method: POST
+      path: /core/data-sources/{id}/sync/
+      access: write
+      description: "Enqueue a sync job for the data source. Returns job ID; poll /core/jobs/{id}/."
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_data_files:
+      method: GET
+      path: /core/data-files/
+      access: read
+      description: "List data files (read-only listing of files synced from data sources)"
+      params:
+        source: { type: integer, in: query }
+        source_id: { type: integer, in: query }
+        path: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_data_file:
+      method: GET
+      path: /core/data-files/{id}/
+      access: read
+      description: "Get a specific data file (metadata + content)"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_jobs:
+      method: GET
+      path: /core/jobs/
+      access: read
+      description: "List background jobs (script runs, data syncs, etc.)"
+      params:
+        object_type: { type: string, in: query }
+        object_id: { type: integer, in: query }
+        status: { type: string, in: query, description: "pending, scheduled, running, completed, errored, failed" }
+        user: { type: integer, in: query }
+        user_id: { type: integer, in: query }
+        name: { type: string, in: query }
+        q: { type: string, in: query }
+        brief: { type: boolean, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_job:
+      method: GET
+      path: /core/jobs/{id}/
+      access: read
+      description: "Get a specific job (status, started/completed times, output data)"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_object_types:
+      method: GET
+      path: /core/object-types/
+      access: read
+      description: "List Django ContentTypes (app_label.model strings used in object_type fields)"
+      params:
+        app_label: { type: string, in: query }
+        model: { type: string, in: query }
+        q: { type: string, in: query }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    get_object_type:
+      method: GET
+      path: /core/object-types/{id}/
+      access: read
+      description: "Get a specific object type"
+      params:
+        id: { type: integer, in: path, required: true }
+      pagination: none
+
+    list_background_queues:
+      method: GET
+      path: /core/background-queues/
+      access: admin
+      description: "List RQ background queues with statistics"
+      params:
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    list_background_workers:
+      method: GET
+      path: /core/background-workers/
+      access: admin
+      description: "List active background workers"
+      params:
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
+
+    list_background_tasks:
+      method: GET
+      path: /core/background-tasks/
+      access: admin
+      description: "List background tasks (RQ jobs)"
+      params:
+        queue: { type: string, in: query }
+        status: { type: string, in: query, description: "queued, started, finished, failed, deferred, scheduled" }
+        limit: { type: integer, in: query }
+        offset: { type: integer, in: query }
 
   examples:
     - name: "Sync VMs from XCP-ng to NetBox"
@@ -3000,3 +8245,134 @@ backend:
           results.push({ device: d.name, interfaces: ifaces.length });
         }
         return results;
+
+    - name: "Carve a new /26 out of a parent prefix"
+      description: "Atomically claim the next free /26 from a parent prefix"
+      code: |
+        const parents = await api.list_prefixes({ prefix: "10.50.0.0/16" });
+        if (!parents.length) return { error: "parent not found" };
+        const child = await api.claim_prefix({
+          id: parents[0].id,
+          prefix_length: 26,
+          status: "active",
+          description: "Carved for new dev pod"
+        });
+        return child;
+
+    - name: "Build a virtual chassis"
+      description: "Create a 3-member stack with master and assign positions"
+      code: |
+        const vc = await api.create_virtual_chassis({ name: "core-stack-1", domain: "core" });
+        const members = [101, 102, 103];
+        for (let i = 0; i < members.length; i++) {
+          await api.update_device({
+            id: members[i],
+            virtual_chassis: vc.id,
+            vc_position: i + 1,
+            vc_priority: i === 0 ? 255 : 128
+          });
+        }
+        await api.update_virtual_chassis({ id: vc.id, master: members[0] });
+        return await api.get_virtual_chassis({ id: vc.id });
+
+    - name: "Reserve rack units"
+      description: "Reserve U38-U40 on a rack for an upcoming install"
+      code: |
+        const racks = await api.list_racks({ name: "DC1-A12", brief: true });
+        return await api.create_rack_reservation({
+          rack: racks[0].id,
+          units: [38, 39, 40],
+          user: 1,
+          description: "Reserved for new firewall pair"
+        });
+
+    - name: "Install a line card module"
+      description: "Pick a free module bay and install a module-type"
+      code: |
+        const bays = await api.list_module_bays({ device: "switch-01", brief: true });
+        const free = bays.find(b => !b.installed_module);
+        if (!free) return { error: "no free bays" };
+        return await api.create_module({
+          device: free.device.id,
+          module_bay: free.id,
+          module_type: 17,
+          status: "active",
+          serial: "ABC123XYZ"
+        });
+
+    - name: "Provision an IPSec site-to-site tunnel"
+      description: "Set up IKE/IPSec policies, profile, tunnel, and both terminations"
+      code: |
+        const ikeProp = await api.create_ike_proposal({
+          name: "ike-aes256-sha256",
+          authentication_method: "preshared-keys",
+          encryption_algorithm: "aes-256-cbc",
+          authentication_algorithm: "hmac-sha256",
+          group: 14
+        });
+        const ikePol = await api.create_ike_policy({
+          name: "ike-pol-1", version: 2, proposals: [ikeProp.id]
+        });
+        const ipsecProp = await api.create_ipsec_proposal({
+          name: "ipsec-aes256-sha256",
+          encryption_algorithm: "aes-256-cbc",
+          authentication_algorithm: "hmac-sha256"
+        });
+        const ipsecPol = await api.create_ipsec_policy({
+          name: "ipsec-pol-1", proposals: [ipsecProp.id], pfs_group: 14
+        });
+        const profile = await api.create_ipsec_profile({
+          name: "site-to-site",
+          mode: "esp",
+          ike_policy: ikePol.id,
+          ipsec_policy: ipsecPol.id
+        });
+        const tunnel = await api.create_tunnel({
+          name: "dc1-to-dc2",
+          encapsulation: "ipsec-tunnel",
+          ipsec_profile: profile.id,
+          status: "active"
+        });
+        await api.create_tunnel_termination({
+          tunnel: tunnel.id, role: "peer",
+          termination_type: "dcim.interface", termination_id: 4001
+        });
+        await api.create_tunnel_termination({
+          tunnel: tunnel.id, role: "peer",
+          termination_type: "dcim.interface", termination_id: 4002
+        });
+        return tunnel;
+
+    - name: "Run a custom script and wait for completion"
+      description: "Execute a NetBox custom script and poll the job until done"
+      code: |
+        const job = await api.run_script({
+          id: 5,
+          data: { device_role: "firewall", site: "dc1" },
+          commit: true
+        });
+        let status = job.status;
+        for (let i = 0; i < 30 && (status === "running" || status === "pending"); i++) {
+          await new Promise(r => setTimeout(r, 2000));
+          const j = await api.get_job({ id: job.job_id || job.id });
+          status = j.status;
+          if (status === "completed" || status === "errored" || status === "failed") return j;
+        }
+        return { job, final_status: status };
+
+    - name: "Assign a primary contact to a device"
+      description: "Create a contact-assignment with the primary role"
+      code: |
+        const contacts = await api.list_contacts({ name: "Network On-Call", brief: true });
+        if (!contacts.length) return { error: "contact not found" };
+        return await api.create_contact_assignment({
+          object_type: "dcim.device",
+          object_id: 1234,
+          contact: contacts[0].id,
+          priority: "primary"
+        });
+
+    - name: "Trace a cable path end to end"
+      description: "Follow a port through patch panels to its far end"
+      code: |
+        return await api.trace_interface({ id: 9001 });


### PR DESCRIPTION
## Summary

Lifts NetBox coverage from **244 → 608 tools** (~98 % of the v4 API surface). Closes most of the gaps the previous version flagged as missing.

## What's new

- **DCIM:** full component-template family, module-types, module-bays, device-bays, virtual-chassis, virtual-device-contexts, inventory-items (+ roles), all port types (console, console-server, power, power-outlet, front, rear) with trace/paths actions, power-panels, power-feeds, mac-addresses, connected-device lookup, rack reservations.
- **IPAM:** ip-ranges with available-ips, vlan-groups with available-vlans, prefixes with available-prefixes + available-ips, asn-ranges with available-asns, route-targets, service-templates, vlan-translation-policies + rules.
- **Virtualization:** virtual-machine-types.
- **Tenancy:** contact-groups, contact-assignments.
- **Circuits:** provider-accounts, provider-networks, terminations paths, group-assignments, virtual-circuit-types, virtual-circuit-terminations.
- **Wireless:** wireless-lan-groups.
- **VPN:** tunnel-groups, tunnel-terminations, ike/ipsec policies + proposals + profiles, l2vpn-terminations.
- **Extras:** webhooks, event-rules, scripts (list/run/result), export-templates, saved-filters, custom-links, image-attachments, bookmarks, notifications, notification-groups, subscriptions, object-changes, journal-entries, config-templates.
- **Users:** users, groups, permissions, tokens, api-tokens.
- **Status & schema** endpoints.

## Still out (~12 endpoints, intentional)

Internal admin/audit surfaces that ToolMesh agents rarely need.

## Validation

`npm run validate` — all 22 DADL files green, including netbox.dadl (608 tools).