### PR TITLE
feat(validate): add path placeholder/param consistency linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "validate": "tsx scripts/validate-all.ts"
+    "validate": "tsx scripts/validate-all.ts",
+    "test:path-params": "tsx scripts/test-path-param-linter.ts",
+    "test": "npm run validate && npm run test:path-params"
   },
   "devDependencies": {
     "ajv": "^8.17.1",

--- a/scripts/test-path-param-linter.ts
+++ b/scripts/test-path-param-linter.ts
@@ -1,0 +1,160 @@
+// Sanity-check the path/param linter from validate-all.ts against synthetic
+// broken DADLs. Not part of CI — run ad-hoc with `tsx scripts/test-path-param-linter.ts`.
+// Mirrors the public helper rather than importing it to keep validate-all.ts
+// a single-file script.
+
+import { parse as parseYaml } from "yaml";
+
+const PATH_PLACEHOLDER_RE = /\{([^/}]+)\}/g;
+
+function findPathParamIssues(doc: any): string[] {
+  const issues: string[] = [];
+  const tools = doc?.backend?.tools;
+  if (!tools || typeof tools !== "object") return issues;
+
+  for (const [toolName, toolRaw] of Object.entries(tools)) {
+    const tool = toolRaw as any;
+    if (!tool || typeof tool !== "object") continue;
+    const path = typeof tool.path === "string" ? tool.path : "";
+    if (!path) continue;
+
+    const params: Record<string, any> =
+      tool.params && typeof tool.params === "object" ? tool.params : {};
+
+    const placeholders = new Set<string>();
+    for (const m of path.matchAll(PATH_PLACEHOLDER_RE)) {
+      placeholders.add(m[1]);
+    }
+
+    for (const placeholder of placeholders) {
+      const def = params[placeholder];
+      if (!def) {
+        issues.push(
+          `tool "${toolName}": path uses {${placeholder}} but no param of that name is declared`,
+        );
+        continue;
+      }
+      if (def.in && def.in !== "path") {
+        issues.push(
+          `tool "${toolName}": path uses {${placeholder}} but param is declared as in="${def.in}"`,
+        );
+      } else if (def.required !== true) {
+        issues.push(
+          `tool "${toolName}": path parameter "${placeholder}" must be declared with required: true`,
+        );
+      }
+    }
+
+    for (const [paramName, defRaw] of Object.entries(params)) {
+      const def = defRaw as any;
+      if (def && def.in === "path" && !placeholders.has(paramName)) {
+        issues.push(
+          `tool "${toolName}": param "${paramName}" is in=path but path "${path}" has no {${paramName}} placeholder`,
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
+const cases: { name: string; yaml: string; expect: string[] }[] = [
+  {
+    name: "happy path",
+    yaml: `
+backend:
+  tools:
+    get_firewall:
+      method: GET
+      path: /networking/firewalls/{firewallId}
+      params:
+        firewallId: { type: integer, in: path, required: true }
+`,
+    expect: [],
+  },
+  {
+    name: "placeholder name != param name (the suspected linode bug)",
+    yaml: `
+backend:
+  tools:
+    get_firewall:
+      method: GET
+      path: /networking/firewalls/{firewall_id}
+      params:
+        firewallId: { type: integer, in: path, required: true }
+`,
+    expect: [
+      `tool "get_firewall": path uses {firewall_id} but no param of that name is declared`,
+      `tool "get_firewall": param "firewallId" is in=path but path "/networking/firewalls/{firewall_id}" has no {firewallId} placeholder`,
+    ],
+  },
+  {
+    name: "param declared as query but used in path",
+    yaml: `
+backend:
+  tools:
+    bad:
+      method: GET
+      path: /things/{id}
+      params:
+        id: { type: integer, in: query }
+`,
+    expect: [`tool "bad": path uses {id} but param is declared as in="query"`],
+  },
+  {
+    name: "path param missing required: true",
+    yaml: `
+backend:
+  tools:
+    bad:
+      method: GET
+      path: /things/{id}
+      params:
+        id: { type: integer, in: path }
+`,
+    expect: [
+      `tool "bad": path parameter "id" must be declared with required: true`,
+    ],
+  },
+  {
+    name: "in:path param without matching placeholder",
+    yaml: `
+backend:
+  tools:
+    bad:
+      method: GET
+      path: /things
+      params:
+        id: { type: integer, in: path, required: true }
+`,
+    expect: [
+      `tool "bad": param "id" is in=path but path "/things" has no {id} placeholder`,
+    ],
+  },
+];
+
+let failed = 0;
+for (const tc of cases) {
+  const doc = parseYaml(tc.yaml);
+  const got = findPathParamIssues(doc);
+  const eq =
+    got.length === tc.expect.length &&
+    tc.expect.every((e) => got.includes(e)) &&
+    got.every((g) => tc.expect.includes(g));
+  if (!eq) {
+    failed++;
+    console.error(`❌ ${tc.name}`);
+    console.error(`   want:`);
+    for (const w of tc.expect) console.error(`     - ${w}`);
+    console.error(`   got:`);
+    for (const g of got) console.error(`     - ${g}`);
+  } else {
+    console.log(`✅ ${tc.name}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} case(s) failed.`);
+  process.exit(1);
+}
+console.log(`\nAll ${cases.length} cases passed.`);

--- a/scripts/validate-all.ts
+++ b/scripts/validate-all.ts
@@ -3,6 +3,8 @@ import { join, basename } from "path";
 import Ajv from "ajv";
 import { parse as parseYaml } from "yaml";
 
+const PATH_PLACEHOLDER_RE = /\{([^/}]+)\}/g;
+
 function findMergeKeys(obj: any, path = ""): string[] {
   const found: string[] = [];
   if (obj && typeof obj === "object") {
@@ -16,6 +18,71 @@ function findMergeKeys(obj: any, path = ""): string[] {
     }
   }
   return found;
+}
+
+// findPathParamIssues catches the class of bugs where a tool's URL template
+// and its `params` map disagree about path parameters. Both directions matter:
+//
+//   1. A `{placeholder}` in `path:` without a matching `in: path` param means
+//      ToolMesh has no value to substitute and the literal `{name}` is sent to
+//      the backend, which typically responds with an opaque 404 that looks
+//      unrelated to the DADL.
+//   2. An `in: path` param whose name does not appear as a `{placeholder}` in
+//      `path:` is dead weight — ToolMesh enforces "required path param" but
+//      never substitutes anywhere, so callers get a confusing "missing param"
+//      error for a parameter that does not actually shape the URL.
+//
+// We also reject path-bound params without `required: true`, because optional
+// path segments produce malformed URLs that vary by backend.
+function findPathParamIssues(doc: any): string[] {
+  const issues: string[] = [];
+  const tools = doc?.backend?.tools;
+  if (!tools || typeof tools !== "object") return issues;
+
+  for (const [toolName, toolRaw] of Object.entries(tools)) {
+    const tool = toolRaw as any;
+    if (!tool || typeof tool !== "object") continue;
+    const path = typeof tool.path === "string" ? tool.path : "";
+    if (!path) continue;
+
+    const params: Record<string, any> =
+      tool.params && typeof tool.params === "object" ? tool.params : {};
+
+    const placeholders = new Set<string>();
+    for (const m of path.matchAll(PATH_PLACEHOLDER_RE)) {
+      placeholders.add(m[1]);
+    }
+
+    for (const placeholder of placeholders) {
+      const def = params[placeholder];
+      if (!def) {
+        issues.push(
+          `tool "${toolName}": path uses {${placeholder}} but no param of that name is declared`,
+        );
+        continue;
+      }
+      if (def.in && def.in !== "path") {
+        issues.push(
+          `tool "${toolName}": path uses {${placeholder}} but param is declared as in="${def.in}"`,
+        );
+      } else if (def.required !== true) {
+        issues.push(
+          `tool "${toolName}": path parameter "${placeholder}" must be declared with required: true`,
+        );
+      }
+    }
+
+    for (const [paramName, defRaw] of Object.entries(params)) {
+      const def = defRaw as any;
+      if (def && def.in === "path" && !placeholders.has(paramName)) {
+        issues.push(
+          `tool "${toolName}": param "${paramName}" is in=path but path "${path}" has no {${paramName}} placeholder`,
+        );
+      }
+    }
+  }
+
+  return issues;
 }
 
 const ROOT_DIR = join(import.meta.dirname, "..");
@@ -71,6 +138,11 @@ for (const file of files) {
     for (const err of validate.errors) {
       errors.push(`Schema: ${err.instancePath || "/"} ${err.message}`);
     }
+  }
+
+  // Path placeholder ↔ param consistency
+  for (const issue of findPathParamIssues(doc)) {
+    errors.push(issue);
   }
 
   // Filename must match backend.name


### PR DESCRIPTION
## Summary

Adds a path-placeholder ↔ params consistency check to `validate-all.ts`, the class of bug we initially suspected was breaking `linode_*_firewall*` per-resource endpoints. (The actual Linode 404 turned out to be a separate float64 formatting bug in ToolMesh's REST adapter — see [DunkelCloud/ToolMesh#75](https://github.com/DunkelCloud/ToolMesh/pull/75). That class of bug would not have been caught by anything here. This PR is the regression net for the *other* class.)

## What the linter rejects

For every tool the validator now reports an error if:

1. The URL template contains `{name}` but `params.name` is missing — runtime would send the literal `{name}` to the backend and get an opaque 404.
2. `params.name.in: path` is set but `{name}` does not appear in the URL — caller hits a confusing "missing required path parameter" error for a param that does not actually shape the URL.
3. A path-bound param is missing `required: true` or is declared with `in: query|body|header` while the URL still references its placeholder.

## What changed

- `scripts/validate-all.ts` — new `findPathParamIssues(doc)` helper, wired into the existing per-file error list. Includes regex for `{placeholder}` extraction and a docstring explaining each failure mode and the runtime symptom it produces.
- `scripts/test-path-param-linter.ts` — sanity-check script with five table-driven cases: happy path + the four failure modes above.
- `package.json` — `npm test` now runs `npm run validate && npm run test:path-params` so CI / pre-commit picks up both.

## Verification

```
$ npm test
…
✅ All 22 DADL files valid.
…
All 5 cases passed.
```

All 22 existing DADLs pass cleanly — no false positives, no path/param mismatches anywhere in the registry today.
