### PR TITLE
docs(elitedomains): show the beta note on the detail page (description → coverage.focus)

### DIFF
--- a/elitedomains.dadl
+++ b/elitedomains.dadl
@@ -61,7 +61,7 @@ backend:
   type: rest
   version: "1.0"
   base_url: https://api.elitedomains.de
-  description: "Beta — the REST API is not yet stable and may still change. ELITEDOMAINS domain registrar API -- register/transfer/manage .de and gTLD domains, redirector & inline DNS, AuthInfo/AuthInfo2 transfer codes, RGP catcher backorders, contact handles, and marketplace offers (Sedo, sale pages)"
+  description: "ELITEDOMAINS domain registrar API -- register/transfer/manage .de and gTLD domains, redirector & inline DNS, AuthInfo/AuthInfo2 transfer codes, RGP catcher backorders, contact handles, and marketplace offers (Sedo, sale pages)"
 
   auth:
     type: bearer
@@ -74,7 +74,7 @@ backend:
     endpoints: 17
     total_endpoints: 17
     percentage: 100
-    focus: "ELITEDOMAINS .de domain reseller: domains (register, transfer, AuthInfo, redirector, DNS records, tags), handles (PERSON, ORG, address validation), catcher (RGP backorders, dropdate, max bid), offers (Sedo marketplace, sale pages, visitor stats)."
+    focus: "Beta — REST API not yet stable. ELITEDOMAINS .de domain reseller: domains (register, transfer, AuthInfo, redirector, DNS records, tags), handles (PERSON, ORG, address validation), catcher (RGP backorders, dropdate, max bid), offers (Sedo marketplace, sale pages, visitor stats)."
     missing: "no standalone DNS-record CRUD (records are managed inline via redirector_settings), no transfer-status polling endpoint, no billing/invoice or price-list endpoints"
     last_reviewed: "2026-06-02"
 


### PR DESCRIPTION
The merged #43 left the beta note in `backend.description`, which only renders on the listing/browse cards and `/llms.txt` — not on the DADL detail page.

This moves the note to the front of `coverage.focus`, which the detail page shows verbatim in its `Focus:` line:

> Beta — REST API not yet stable. ELITEDOMAINS .de domain reseller: domains (…), handles (…), catcher (…), offers (…).

Placement avoids the area-parser problem: the note sits **before the first `:`** (the parser only comma-walks the part after it) and uses **no** `full`/`v#`/`coverage`/`:` marker (the second extraction pass). Verified with `analyze-dadl.ts` — areas stay Domain, Catcher, Handle, Offer, Address, Authinfo and the generated meta description is unchanged.

Net change vs main: beta note removed from `description`, added to `coverage.focus` (2 lines).