### PR TITLE
fix: correct path-encoding guidance and param traps in gitlab.dadl

### DIFF
--- a/gitlab.dadl
+++ b/gitlab.dadl
@@ -13,10 +13,10 @@ backend:
   description: "GitLab REST API v4 — projects, issues, merge requests, pipelines, CI/CD, and code search"
 
   coverage:
-    endpoints: 52
+    endpoints: 75
     total_endpoints: 400
-    percentage: 13
-    focus: "projects, issues, merge requests, branches, commits, pipelines, jobs, releases, groups, users, repository files, labels, milestones, search"
+    percentage: 19
+    focus: "GitLab REST API v4: projects, issues, merge requests, pipelines, jobs, branches, commits, releases, groups, users, repository files, labels, milestones, code search"
     missing: "deploy tokens, container registry, packages, wikis, snippets, epics, environments, cluster agents, protected branches, webhooks, project hooks"
     last_reviewed: "2026-03-26"
 
@@ -30,7 +30,7 @@ backend:
     backends_yaml: |
       - name: gitlab
         transport: rest
-        dadl: /app/dadl/gitlab.dadl
+        dadl: gitlab.dadl
         url: "https://your-gitlab.example.com/api/v4"
     required_scopes:
       - api
@@ -49,8 +49,9 @@ backend:
 
   defaults:
     headers:
-      Content-Type: application/json
       Accept: application/json
+    # No Content-Type here: the runtime defaults request bodies to
+    # application/json and only sets the header when a body is actually sent.
     pagination: &default-pagination
       strategy: page
       request:
@@ -60,6 +61,8 @@ backend:
       response:
         total_pages_header: x-total-pages
         total_count_header: x-total
+      # expose: the LLM passes page/per_page itself. GitLab list endpoints are
+      # broad, so transparent all-page fetching (auto) would flood the context.
       behavior: expose
       max_pages: 10
     errors: &standard-errors
@@ -71,14 +74,22 @@ backend:
         max_retries: 3
         backoff: exponential
         initial_delay: 1s
+      # Rate-limit headers (RateLimit-Limit/-Remaining/-Reset/-Observed,
+      # Retry-After on 429) are documented in the domain notes below; the
+      # runtime does not act on them, so no errors.rate_limit block here.
 
   # ──────────────────────────────────────────────────────────────
   # Domain notes (for LLM consumers of these tools)
   #
   # ID parameter:
   #   Most endpoints accept either a numeric project/group ID or a
-  #   URL-encoded namespace path (e.g., "my-group%2Fmy-project").
-  #   Forward slashes in paths must be URL-encoded as %2F.
+  #   namespace path (e.g., "my-group/my-project").
+  #   Pass the path with PLAIN forward slashes — do NOT pre-encode them
+  #   as %2F. ToolMesh URL-escapes path parameters itself; a pre-encoded
+  #   "%2F" is escaped again to "%252F" and the call 404s. Verified live
+  #   against gitlab.dunkel.io 2026-08-05: id "infra/monitoring-config"
+  #   resolves, "infra%2Fmonitoring-config" returns 404. The same applies
+  #   to file_path ("config/rules/hosts.yml", not "config%2Frules%2F...").
   #
   # IID vs ID:
   #   GitLab uses "iid" (internal ID) for project-scoped numbering
@@ -105,10 +116,18 @@ backend:
   #   Validation errors nest by field name with arrays of messages.
   #
   # Dates:
-  #   ISO 8601 format. Encode '+' in timezone offsets as %2B.
+  #   ISO 8601 format. Pass timezone offsets literally
+  #   ("2026-01-01T00:00:00+02:00"); query values are escaped for you.
   #
   # Arrays in params:
-  #   Use param[]=value1&param[]=value2 syntax.
+  #   Array-typed BODY params (assignee_ids, reviewer_ids) work — they are
+  #   marshalled as a real JSON array.
+  #   Array-typed QUERY params do NOT work through ToolMesh: the value is
+  #   stringified to "[66 65]" instead of iids[]=66&iids[]=65, so the filter
+  #   matches nothing and you get an empty list back rather than an error.
+  #   GitLab's iids[] filters are therefore not exposed. To fetch specific
+  #   items, call the per-item tool (get_merge_request / get_project_issue)
+  #   or filter client-side after a list call.
   # ──────────────────────────────────────────────────────────────
 
   tools:
@@ -139,7 +158,7 @@ backend:
       method: GET
       path: /projects/{id}
       access: read
-      description: "Get a single project by ID or URL-encoded path (e.g., 'my-group%2Fmy-project')."
+      description: "Get a single project by numeric ID or namespace path with plain slashes (e.g., 'my-group/my-project'). Do not pre-encode slashes as %2F — that 404s."
       params:
         id: { type: string, in: path, required: true }
         license: { type: boolean, in: query }
@@ -248,7 +267,9 @@ backend:
         search: { type: string, in: query }
         order_by: { type: string, in: query, default: "created_at" }
         sort: { type: string, in: query, default: "desc" }
-        iids: { type: array, in: query }
+        # GitLab's iids[] filter is intentionally not exposed: array query
+        # params serialize to the literal "[66 65]" (see domain notes), which
+        # matches nothing and returns an empty list instead of an error.
         page: { type: integer, in: query }
         per_page: { type: integer, in: query, default: 20 }
 
@@ -369,7 +390,7 @@ backend:
         search: { type: string, in: query }
         order_by: { type: string, in: query, default: "created_at" }
         sort: { type: string, in: query, default: "desc" }
-        iids: { type: array, in: query }
+        # iids[] omitted — see list_project_issues above and the domain notes.
         page: { type: integer, in: query }
         per_page: { type: integer, in: query, default: 20 }
 
@@ -854,7 +875,7 @@ backend:
       method: GET
       path: /groups/{id}
       access: read
-      description: "Get details of a group by ID or URL-encoded path."
+      description: "Get details of a group by numeric ID or full path with plain slashes (e.g. 'parent-group/subgroup')."
       params:
         id: { type: string, in: path, required: true }
         with_projects: { type: boolean, in: query }
@@ -918,11 +939,11 @@ backend:
 
     get_user:
       method: GET
-      path: /users/{user_id}
+      path: /users/{id}
       access: read
-      description: "Get a single user by ID. Admins see extended fields including sign-in history."
+      description: "Get a single user by numeric user ID. Admins see extended fields including sign-in history."
       params:
-        user_id: { type: integer, in: path, required: true }
+        id: { type: integer, in: path, required: true }
       pagination: none
 
     # ── Repository Files ─────────────────────────────────────────
@@ -931,7 +952,7 @@ backend:
       method: GET
       path: /projects/{id}/repository/files/{file_path}
       access: read
-      description: "Get file metadata and base64-encoded content. The file_path must be URL-encoded (slashes as %2F)."
+      description: "Get file metadata and base64-encoded content. Pass file_path with plain slashes (e.g. 'config/rules/hosts.yml'); do not pre-encode them as %2F."
       params:
         id: { type: string, in: path, required: true }
         file_path: { type: string, in: path, required: true }


### PR DESCRIPTION
Live-verified against a production GitLab v4 instance through ToolMesh. Every change here addresses guidance or a parameter that produced **wrong results**, not style.

Builds on #59, which already fixed the `behavior: manual` load error and the no-op pagination fields.

### Path encoding advice was backwards

The domain notes instructed consumers to URL-encode slashes as `%2F`. That is correct for raw HTTP calls but wrong through ToolMesh, whose `buildPath` already applies `url.PathEscape` — a pre-encoded `%2F` becomes `%252F` and the call 404s.

| call | result |
|---|---|
| `get_project({id: "infra/monitoring-config"})` | resolves |
| `get_project({id: "infra%2Fmonitoring-config"})` | 404 |
| `get_file({file_path: "config/rules/hosts.yml"})` | 7362 bytes |
| `get_file({file_path: "config%2Frules%2Fhosts.yml"})` | 404 |

The advice appeared in five places, including the `get_project`, `get_group` and `get_file` descriptions — i.e. exactly where an LLM consumer reads it. All corrected.

### iids[] filters returned an empty list instead of an error

Array-typed query params are stringified to the literal `[66 65]` instead of `iids[]=66&iids[]=65`, so the filter matches nothing. Measured on a project with 10 merge requests: no filter returns 10, `iids: [66]` returns 0 (expected 1), `iids: [66, 65]` returns 0 (expected 2) — with no error raised. A caller would reasonably conclude "nothing matches".

Silently wrong results are worse than an absent parameter, so both `iids` params are dropped and the limitation documented. Array *body* params (`assignee_ids`, `reviewer_ids`) are unaffected — they marshal as real JSON arrays.

This is a runtime limitation rather than a GitLab quirk: 32 array query params across 9 DADLs are affected. Worth fixing centrally in `buildQuery`, at which point these params can come back.

### get_user broke the file's own naming convention

`/users/{user_id}` while all 65 other primary lookups use `{id}`; qualified names are reserved for sub-resources like `/projects/{id}/jobs/{job_id}`. GitLab documents the endpoint as `/users/:id`. An LLM that has learned `get_project({id})` will inevitably write `get_user({id})` and hit a hard error. Renamed to `{id}`.

### Smaller corrections

- **Dates:** timezone offsets are escaped by the runtime, so the advice to pre-encode `+` as `%2B` is dropped.
- **Content-Type:** removed from `defaults.headers`. The runtime defaults bodies to `application/json` and sets the header only when a body is present, so the explicit entry was putting `Content-Type` on bodyless GETs. Added a note on why `errors.rate_limit` is deliberately absent, matching the shelly-cloud approach in #59.
- **coverage:** `endpoints` 52 → 75 (the actual tool count), `percentage` 13 → 19, and `focus` given the documented "Headline: areas" shape. Verified with `analyze-dadl.ts` that the derived areas are unchanged (Project, Pipeline, Group, Merge).
- **setup.backends_yaml:** takes a bare filename, not an absolute container path.

### Verification

`npm test` green (all 28 files valid against the v0.2 schema, path-param linter passes) and `lint-dadl` clean. 74 of 75 tools exercised live against the instance; the write tools were deliberately not run.